### PR TITLE
[Merged by Bors] - Added owner-ref to pod templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 - Include chart name when installing with a custom release name ([#97])
 - Pinned MinIO version for tests ([#100])
 - `operator-rs` `0.21.0` → `0.22.0` ([#102]).
-- added owner-reference to pod templates ([#104])
+- Added owner-reference to pod templates ([#104])
 
 [#97]: https://github.com/stackabletech/spark-k8s-operator/pull/92
 [#100]: https://github.com/stackabletech/spark-k8s-operator/pull/100

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ All notable changes to this project will be documented in this file.
 - Include chart name when installing with a custom release name ([#97])
 - Pinned MinIO version for tests ([#100])
 - `operator-rs` `0.21.0` → `0.22.0` ([#102]).
+- added owner-reference to pod templates ([#104])
 
 [#97]: https://github.com/stackabletech/spark-k8s-operator/pull/92
 [#100]: https://github.com/stackabletech/spark-k8s-operator/pull/100
 [#102]: https://github.com/stackabletech/spark-k8s-operator/pull/102
+[#104]: https://github.com/stackabletech/spark-k8s-operator/pull/104
 
 ## [0.3.0] - 2022-06-30
 

--- a/examples/ny-tlc-report-external-dependencies.yaml
+++ b/examples/ny-tlc-report-external-dependencies.yaml
@@ -10,7 +10,7 @@ spec:
   # Always | IfNotPresent | Never
   sparkImagePullPolicy: IfNotPresent
   mode: cluster
-  mainApplicationFile: s3a://my-bucket/ny-tlc-report.py
+  mainApplicationFile: s3a://my-bucket/ny_tlc_report.py
   args:
     - "--input 's3a://my-bucket/yellow_tripdata_2021-07.csv'"
   deps:

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -485,6 +485,7 @@ mod tests {
     use crate::ImagePullPolicy;
     use crate::LocalObjectReference;
     use crate::SparkApplication;
+    use stackable_operator::builder::ObjectMetaBuilder;
     use stackable_operator::commons::s3::{
         S3AccessStyle, S3BucketSpec, S3ConnectionDef, S3ConnectionSpec,
     };
@@ -609,6 +610,7 @@ kind: SparkApplication
 metadata:
   name: ny-tlc-report-external-dependencies
   namespace: default
+  uid: 12345678asdfghj
 spec:
   version: "1.0"
   sparkImage: docker.stackable.tech/stackable/spark-k8s:3.2.1-hadoop3.2-python39-aws1.11.375-stackable0.3.0
@@ -630,6 +632,14 @@ spec:
     instances: 3
     memory: "512m"
         "#).unwrap();
+
+        let meta = ObjectMetaBuilder::new()
+            .name_and_namespace(&spark_application)
+            .ownerreference_from_resource(&spark_application, None, Some(true))
+            .unwrap()
+            .build();
+
+        assert_eq!("12345678asdfghj", meta.owner_references.unwrap()[0].uid);
 
         assert_eq!("1.0", spark_application.spec.version.unwrap_or_default());
         assert_eq!(

--- a/rust/operator-binary/src/spark_k8s_controller.rs
+++ b/rust/operator-binary/src/spark_k8s_controller.rs
@@ -253,7 +253,9 @@ fn pod_template(
     Ok(Pod {
         metadata: ObjectMetaBuilder::new()
             .name(container_name)
-            .ownerreference_from_resource(spark_application, None, Some(false))
+            // this reference is not pointing to a controller but only provides a UID that can used to clean up resources
+            // cleanly (specifically driver pods and related config maps) when the spark application is deleted.
+            .ownerreference_from_resource(spark_application, None, None)
             .context(ObjectMissingMetadataForOwnerRefSnafu)?
             .with_labels(spark_application.recommended_labels())
             .build(),

--- a/rust/operator-binary/src/spark_k8s_controller.rs
+++ b/rust/operator-binary/src/spark_k8s_controller.rs
@@ -253,6 +253,8 @@ fn pod_template(
     Ok(Pod {
         metadata: ObjectMetaBuilder::new()
             .name(container_name)
+            .ownerreference_from_resource(spark_application, None, Some(false))
+            .context(ObjectMissingMetadataForOwnerRefSnafu)?
             .with_labels(spark_application.recommended_labels())
             .build(),
         spec: Some(pod_spec),


### PR DESCRIPTION
# Description

- added an owner-reference to the pod templates for driver and executor(s) so that their pods are cleaned up along with the SparkApplication
- also fixed broken file name in one of the examples

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [x] Code contains useful comments
- [x] CRD change approved (or not applicable)
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
