### PR TITLE
Fix resources test: replace yq usage with standard tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ All notable changes to this project will be documented in this file.
 
 - Bumped image to `3.3.0-stackable0.2.0` in tests and docs ([#145])
 - BREAKING: use resource limit struct instead of passing spark configuration arguments ([#147])
+- Fixed resources test ([#150])
 
 [#145]: https://github.com/stackabletech/spark-k8s-operator/pull/145
 [#147]: https://github.com/stackabletech/spark-k8s-operator/pull/147
+[#150]: https://github.com/stackabletech/spark-k8s-operator/pull/150
 
 ## [0.5.0] - 2022-09-06
 

--- a/tests/templates/kuttl/resources/13-assert.yaml
+++ b/tests/templates/kuttl/resources/13-assert.yaml
@@ -4,7 +4,6 @@ kind: TestAssert
 timeout: 240
 skipLogOutput: true
 commands:
-  - script: kubectl get cm -n $NAMESPACE spark-resources-pod-template -o yaml | yq -r '.data."driver.yml"' | yq -r '.spec.containers[0].resources.limits.cpu' | grep 1500m
-  - script: kubectl get cm -n $NAMESPACE spark-resources-pod-template -o yaml | yq -r '.data."driver.yml"' | yq -r '.spec.containers[0].resources.requests.cpu' | grep 1
-  - script: kubectl get cm -n $NAMESPACE spark-resources-pod-template -o yaml | yq -r '.data."executor.yml"' | yq -r '.spec.containers[0].resources.limits.cpu' | grep 2
-  - script: kubectl get cm -n $NAMESPACE spark-resources-pod-template -o yaml | yq -r '.data."executor.yml"' | yq -r '.spec.containers[0].resources.requests.cpu' | grep 1
+  # read the config map, stripping indents and new lines and doing some replacement, then grepping for the relevant section
+  - script: kubectl get cm -n $NAMESPACE spark-resources-pod-template -o yaml | sed -e 's/^\s*//' -e '/^$/d' | tr '\n' ' ' | tr ':' '|' | grep -o 'spark-driver resources| limits| cpu| 1500m memory| 1Gi requests| cpu| "1" memory| 1Gi'
+  - script: kubectl get cm -n $NAMESPACE spark-resources-pod-template -o yaml | sed -e 's/^\s*//' -e '/^$/d' | tr '\n' ' ' | tr ':' '|' | grep -o 'spark-executor resources| limits| cpu| "2" memory| 1Gi requests| cpu| "1" memory| 1Gi'


### PR DESCRIPTION
# Description

Utilities like `jq` and `yq` cannot to be assumed to be available where tests run. Their usage has been replaced with standard command-line tools.

Jenkins: https://ci.stackable.tech/view/02%20Operator%20Tests%20(custom)/job/spark-k8s-operator-it-custom/36/

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] CRD change approved (or not applicable)
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
