### PR TITLE
Product image selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ All notable changes to this project will be documented in this file.
 - Updated stackable image versions ([#176])
 - `operator-rs` `0.22.0` → `0.27.1` ([#178])
 - Don't run init container as root and avoid chmod and chowning ([#183])
-- [BREAKING] The `spec.sparkImage` now uses product image selection instead of just an image string ([#186])
+- [BREAKING] The `spec.sparkImage` and `spec.image` now uses product image selection instead of just an image string ([#186])
 
 ### Removed
 
-- [BREAKING] Removed `spec.sparkImagePullPolicy` and `spec.sparkImagePullSecrets` which is coverd via product image selection in `spec.sparkImage` ([#186])
+- [BREAKING] Removed `spec.sparkImagePullPolicy` and `spec.sparkImagePullSecrets` which is covered via product image selection in `spec.sparkImage` ([#186])
 
 [#176]: https://github.com/stackabletech/spark-k8s-operator/pull/176
 [#178]: https://github.com/stackabletech/spark-k8s-operator/pull/178

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,16 @@ All notable changes to this project will be documented in this file.
 - Updated stackable image versions ([#176])
 - `operator-rs` `0.22.0` → `0.27.1` ([#178])
 - Don't run init container as root and avoid chmod and chowning ([#183])
+- [BREAKING] The `spec.sparkImage` now uses product image selection instead of just an image string ([#186])
+
+### Removed
+
+- [BREAKING] Removed `spec.sparkImagePullPolicy` and `spec.sparkImagePullSecrets` which is coverd via product image selection in `spec.sparkImage` ([#186])
 
 [#176]: https://github.com/stackabletech/spark-k8s-operator/pull/176
 [#178]: https://github.com/stackabletech/spark-k8s-operator/pull/178
 [#183]: https://github.com/stackabletech/spark-k8s-operator/pull/183
+[#186]: https://github.com/stackabletech/spark-k8s-operator/pull/186
 
 ## [0.6.0] - 2022-11-07
 

--- a/deploy/crd/sparkapplication.crd.yaml
+++ b/deploy/crd/sparkapplication.crd.yaml
@@ -493,7 +493,7 @@ spec:
                 - required:
                   - productVersion
                   - stackableVersion
-                description: An external / custom image to provide extra data or libraries This should always be `CustomImage` as described in https://docs.stackable.tech/home/nightly/concepts/product_image_selection.html#_custom_images.
+                description: An external / custom image to provide extra data or libraries This should always be `CustomImage` as described in `<https://docs.stackable.tech/home/nightly/concepts/product_image_selection.html#_custom_images>`.
                 nullable: true
                 properties:
                   custom:

--- a/deploy/crd/sparkapplication.crd.yaml
+++ b/deploy/crd/sparkapplication.crd.yaml
@@ -486,8 +486,49 @@ spec:
                     type: array
                 type: object
               image:
+                anyOf:
+                - required:
+                  - custom
+                  - productVersion
+                - required:
+                  - productVersion
+                  - stackableVersion
+                description: An external / custom image to provide extra data or libraries This should always be `CustomImage` as described in https://docs.stackable.tech/home/nightly/concepts/product_image_selection.html#_custom_images.
                 nullable: true
-                type: string
+                properties:
+                  custom:
+                    description: Overwrite the docker image. Specify the full docker image name, e.g. `docker.stackable.tech/stackable/superset:1.4.1-stackable2.1.0`
+                    type: string
+                  productVersion:
+                    description: Version of the product, e.g. `1.4.1`.
+                    type: string
+                  pullPolicy:
+                    default: IfNotPresent
+                    description: '[Pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) used when pulling the Images'
+                    enum:
+                    - IfNotPresent
+                    - Always
+                    - Never
+                    type: string
+                  pullSecrets:
+                    description: '[Image pull secrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod) to pull images from a private registry'
+                    items:
+                      description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  repo:
+                    description: Name of the docker repo, e.g. `docker.stackable.tech/stackable`
+                    nullable: true
+                    type: string
+                  stackableVersion:
+                    description: Stackable version of the product, e.g. 2.1.0
+                    type: string
+                type: object
               job:
                 nullable: true
                 properties:

--- a/deploy/crd/sparkapplication.crd.yaml
+++ b/deploy/crd/sparkapplication.crd.yaml
@@ -747,25 +747,49 @@ spec:
                 nullable: true
                 type: object
               sparkImage:
+                anyOf:
+                - required:
+                  - custom
+                  - productVersion
+                - required:
+                  - productVersion
+                  - stackableVersion
+                description: The Spark image to use
                 nullable: true
-                type: string
-              sparkImagePullPolicy:
-                enum:
-                - Always
-                - IfNotPresent
-                - Never
-                nullable: true
-                type: string
-              sparkImagePullSecrets:
-                items:
-                  description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
-                  properties:
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                      type: string
-                  type: object
-                nullable: true
-                type: array
+                properties:
+                  custom:
+                    description: Overwrite the docker image. Specify the full docker image name, e.g. `docker.stackable.tech/stackable/superset:1.4.1-stackable2.1.0`
+                    type: string
+                  productVersion:
+                    description: Version of the product, e.g. `1.4.1`.
+                    type: string
+                  pullPolicy:
+                    default: IfNotPresent
+                    description: '[Pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) used when pulling the Images'
+                    enum:
+                    - IfNotPresent
+                    - Always
+                    - Never
+                    type: string
+                  pullSecrets:
+                    description: '[Image pull secrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod) to pull images from a private registry'
+                    items:
+                      description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  repo:
+                    description: Name of the docker repo, e.g. `docker.stackable.tech/stackable`
+                    nullable: true
+                    type: string
+                  stackableVersion:
+                    description: Stackable version of the product, e.g. 2.1.0
+                    type: string
+                type: object
               stopped:
                 nullable: true
                 type: boolean

--- a/deploy/helm/spark-k8s-operator/crds/crds.yaml
+++ b/deploy/helm/spark-k8s-operator/crds/crds.yaml
@@ -495,7 +495,7 @@ spec:
                     - required:
                         - productVersion
                         - stackableVersion
-                  description: An external / custom image to provide extra data or libraries This should always be `CustomImage` as described in https://docs.stackable.tech/home/nightly/concepts/product_image_selection.html#_custom_images.
+                  description: An external / custom image to provide extra data or libraries This should always be `CustomImage` as described in `<https://docs.stackable.tech/home/nightly/concepts/product_image_selection.html#_custom_images>`.
                   nullable: true
                   properties:
                     custom:

--- a/deploy/helm/spark-k8s-operator/crds/crds.yaml
+++ b/deploy/helm/spark-k8s-operator/crds/crds.yaml
@@ -488,8 +488,49 @@ spec:
                       type: array
                   type: object
                 image:
+                  anyOf:
+                    - required:
+                        - custom
+                        - productVersion
+                    - required:
+                        - productVersion
+                        - stackableVersion
+                  description: An external / custom image to provide extra data or libraries This should always be `CustomImage` as described in https://docs.stackable.tech/home/nightly/concepts/product_image_selection.html#_custom_images.
                   nullable: true
-                  type: string
+                  properties:
+                    custom:
+                      description: Overwrite the docker image. Specify the full docker image name, e.g. `docker.stackable.tech/stackable/superset:1.4.1-stackable2.1.0`
+                      type: string
+                    productVersion:
+                      description: Version of the product, e.g. `1.4.1`.
+                      type: string
+                    pullPolicy:
+                      default: IfNotPresent
+                      description: '[Pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) used when pulling the Images'
+                      enum:
+                        - IfNotPresent
+                        - Always
+                        - Never
+                      type: string
+                    pullSecrets:
+                      description: '[Image pull secrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod) to pull images from a private registry'
+                      items:
+                        description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        type: object
+                      nullable: true
+                      type: array
+                    repo:
+                      description: Name of the docker repo, e.g. `docker.stackable.tech/stackable`
+                      nullable: true
+                      type: string
+                    stackableVersion:
+                      description: Stackable version of the product, e.g. 2.1.0
+                      type: string
+                  type: object
                 job:
                   nullable: true
                   properties:

--- a/deploy/helm/spark-k8s-operator/crds/crds.yaml
+++ b/deploy/helm/spark-k8s-operator/crds/crds.yaml
@@ -749,25 +749,49 @@ spec:
                   nullable: true
                   type: object
                 sparkImage:
+                  anyOf:
+                    - required:
+                        - custom
+                        - productVersion
+                    - required:
+                        - productVersion
+                        - stackableVersion
+                  description: The Spark image to use
                   nullable: true
-                  type: string
-                sparkImagePullPolicy:
-                  enum:
-                    - Always
-                    - IfNotPresent
-                    - Never
-                  nullable: true
-                  type: string
-                sparkImagePullSecrets:
-                  items:
-                    description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
-                    properties:
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                    type: object
-                  nullable: true
-                  type: array
+                  properties:
+                    custom:
+                      description: Overwrite the docker image. Specify the full docker image name, e.g. `docker.stackable.tech/stackable/superset:1.4.1-stackable2.1.0`
+                      type: string
+                    productVersion:
+                      description: Version of the product, e.g. `1.4.1`.
+                      type: string
+                    pullPolicy:
+                      default: IfNotPresent
+                      description: '[Pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) used when pulling the Images'
+                      enum:
+                        - IfNotPresent
+                        - Always
+                        - Never
+                      type: string
+                    pullSecrets:
+                      description: '[Image pull secrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod) to pull images from a private registry'
+                      items:
+                        description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        type: object
+                      nullable: true
+                      type: array
+                    repo:
+                      description: Name of the docker repo, e.g. `docker.stackable.tech/stackable`
+                      nullable: true
+                      type: string
+                    stackableVersion:
+                      description: Stackable version of the product, e.g. 2.1.0
+                      type: string
+                  type: object
                 stopped:
                   nullable: true
                   type: boolean

--- a/deploy/manifests/crds.yaml
+++ b/deploy/manifests/crds.yaml
@@ -750,25 +750,49 @@ spec:
                   nullable: true
                   type: object
                 sparkImage:
+                  anyOf:
+                    - required:
+                        - custom
+                        - productVersion
+                    - required:
+                        - productVersion
+                        - stackableVersion
+                  description: The Spark image to use
                   nullable: true
-                  type: string
-                sparkImagePullPolicy:
-                  enum:
-                    - Always
-                    - IfNotPresent
-                    - Never
-                  nullable: true
-                  type: string
-                sparkImagePullSecrets:
-                  items:
-                    description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
-                    properties:
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                    type: object
-                  nullable: true
-                  type: array
+                  properties:
+                    custom:
+                      description: Overwrite the docker image. Specify the full docker image name, e.g. `docker.stackable.tech/stackable/superset:1.4.1-stackable2.1.0`
+                      type: string
+                    productVersion:
+                      description: Version of the product, e.g. `1.4.1`.
+                      type: string
+                    pullPolicy:
+                      default: IfNotPresent
+                      description: '[Pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) used when pulling the Images'
+                      enum:
+                        - IfNotPresent
+                        - Always
+                        - Never
+                      type: string
+                    pullSecrets:
+                      description: '[Image pull secrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod) to pull images from a private registry'
+                      items:
+                        description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        type: object
+                      nullable: true
+                      type: array
+                    repo:
+                      description: Name of the docker repo, e.g. `docker.stackable.tech/stackable`
+                      nullable: true
+                      type: string
+                    stackableVersion:
+                      description: Stackable version of the product, e.g. 2.1.0
+                      type: string
+                  type: object
                 stopped:
                   nullable: true
                   type: boolean

--- a/deploy/manifests/crds.yaml
+++ b/deploy/manifests/crds.yaml
@@ -496,7 +496,7 @@ spec:
                     - required:
                         - productVersion
                         - stackableVersion
-                  description: An external / custom image to provide extra data or libraries This should always be `CustomImage` as described in https://docs.stackable.tech/home/nightly/concepts/product_image_selection.html#_custom_images.
+                  description: An external / custom image to provide extra data or libraries This should always be `CustomImage` as described in `<https://docs.stackable.tech/home/nightly/concepts/product_image_selection.html#_custom_images>`.
                   nullable: true
                   properties:
                     custom:

--- a/deploy/manifests/crds.yaml
+++ b/deploy/manifests/crds.yaml
@@ -489,8 +489,49 @@ spec:
                       type: array
                   type: object
                 image:
+                  anyOf:
+                    - required:
+                        - custom
+                        - productVersion
+                    - required:
+                        - productVersion
+                        - stackableVersion
+                  description: An external / custom image to provide extra data or libraries This should always be `CustomImage` as described in https://docs.stackable.tech/home/nightly/concepts/product_image_selection.html#_custom_images.
                   nullable: true
-                  type: string
+                  properties:
+                    custom:
+                      description: Overwrite the docker image. Specify the full docker image name, e.g. `docker.stackable.tech/stackable/superset:1.4.1-stackable2.1.0`
+                      type: string
+                    productVersion:
+                      description: Version of the product, e.g. `1.4.1`.
+                      type: string
+                    pullPolicy:
+                      default: IfNotPresent
+                      description: '[Pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) used when pulling the Images'
+                      enum:
+                        - IfNotPresent
+                        - Always
+                        - Never
+                      type: string
+                    pullSecrets:
+                      description: '[Image pull secrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod) to pull images from a private registry'
+                      items:
+                        description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        type: object
+                      nullable: true
+                      type: array
+                    repo:
+                      description: Name of the docker repo, e.g. `docker.stackable.tech/stackable`
+                      nullable: true
+                      type: string
+                    stackableVersion:
+                      description: Stackable version of the product, e.g. 2.1.0
+                      type: string
+                  type: object
                 job:
                   nullable: true
                   properties:

--- a/docs/modules/ROOT/examples/example-encapsulated.yaml
+++ b/docs/modules/ROOT/examples/example-encapsulated.yaml
@@ -5,7 +5,9 @@ metadata:
   name: spark-pi
 spec:
   version: "1.0"
-  sparkImage: docker.stackable.tech/stackable/spark-k8s:3.3.0-stackable0.3.0 # <1>
+  sparkImage: # <1>
+    productVersion: 3.3.0
+    stackableVersion: 0.3.0
   mode: cluster
   mainClass: org.apache.spark.examples.SparkPi
   mainApplicationFile: /stackable/spark/examples/jars/spark-examples_2.12-3.3.0.jar # <2>

--- a/docs/modules/ROOT/examples/example-sparkapp-configmap.yaml
+++ b/docs/modules/ROOT/examples/example-sparkapp-configmap.yaml
@@ -6,7 +6,9 @@ metadata:
   namespace: default
 spec:
   version: "1.0"
-  sparkImage: docker.stackable.tech/stackable/spark-k8s:3.3.0-stackable0.3.0
+  sparkImage:
+    productVersion: 3.3.0
+    stackableVersion: 0.3.0
   mode: cluster
   mainApplicationFile: s3a://stackable-spark-k8s-jars/jobs/ny-tlc-report-1.1.0.jar # <3>
   mainClass: tech.stackable.demo.spark.NYTLCReport

--- a/docs/modules/ROOT/examples/example-sparkapp-external-dependencies.yaml
+++ b/docs/modules/ROOT/examples/example-sparkapp-external-dependencies.yaml
@@ -6,7 +6,9 @@ metadata:
   namespace: default
 spec:
   version: "1.0"
-  sparkImage: docker.stackable.tech/stackable/pyspark-k8s:3.3.0-stackable0.3.0
+  sparkImage:
+    custom: docker.stackable.tech/stackable/pyspark-k8s:3.3.0-stackable0.3.0
+    productVersion: 3.3.0
   mode: cluster
   mainApplicationFile: s3a://stackable-spark-k8s-jars/jobs/ny_tlc_report.py # <1>
   args:

--- a/docs/modules/ROOT/examples/example-sparkapp-image.yaml
+++ b/docs/modules/ROOT/examples/example-sparkapp-image.yaml
@@ -6,8 +6,12 @@ metadata:
   namespace: default
 spec:
   version: "1.0"
-  image: docker.stackable.tech/stackable/ny-tlc-report:0.1.0 # <1>
-  sparkImage: docker.stackable.tech/stackable/pyspark-k8s:3.3.0-stackable0.3.0
+  image:
+    custom: docker.stackable.tech/stackable/ny-tlc-report:0.1.0 # <1>
+    productVersion: 0.1.0
+  sparkImage:
+    custom: docker.stackable.tech/stackable/pyspark-k8s:3.3.0-stackable0.3.0
+    productVersion: 3.3.0
   mode: cluster
   mainApplicationFile: local:///stackable/spark/jobs/ny_tlc_report.py # <2>
   args:

--- a/docs/modules/ROOT/examples/example-sparkapp-pvc.yaml
+++ b/docs/modules/ROOT/examples/example-sparkapp-pvc.yaml
@@ -6,7 +6,9 @@ metadata:
   namespace: default
 spec:
   version: "1.0"
-  sparkImage: docker.stackable.tech/stackable/spark-k8s:3.3.0-stackable0.3.0
+  sparkImage:
+    custom: docker.stackable.tech/stackable/pyspark-k8s:3.3.0-stackable0.3.0
+    productVersion: 3.3.0
   mode: cluster
   mainApplicationFile: s3a://stackable-spark-k8s-jars/jobs/ny-tlc-report-1.0-SNAPSHOT.jar # <1>
   mainClass: org.example.App # <2>

--- a/docs/modules/ROOT/examples/example-sparkapp-s3-private.yaml
+++ b/docs/modules/ROOT/examples/example-sparkapp-s3-private.yaml
@@ -5,7 +5,9 @@ metadata:
   name: example-sparkapp-s3-private
 spec:
   version: "1.0"
-  sparkImage: docker.stackable.tech/stackable/spark-k8s:3.3.0-stackable0.3.0
+  sparkImage:
+    productVersion: 3.3.0
+    stackableVersion: 0.3.0
   mode: cluster
   mainApplicationFile: s3a://my-bucket/spark-examples_2.12-3.3.0.jar # <1>
   mainClass: org.apache.spark.examples.SparkPi # <2>

--- a/docs/modules/ROOT/examples/example-sparkapp-streaming.yaml
+++ b/docs/modules/ROOT/examples/example-sparkapp-streaming.yaml
@@ -6,7 +6,9 @@ metadata:
   namespace: default
 spec:
   version: "1.0"
-  sparkImage: docker.stackable.tech/stackable/pyspark-k8s:3.3.0-stackable0.3.0
+  sparkImage:
+    custom: docker.stackable.tech/stackable/pyspark-k8s:3.3.0-stackable0.3.0
+    productVersion: 3.3.0
   mode: cluster
   mainApplicationFile: local:///stackable/spark/examples/src/main/python/streaming/hdfs_wordcount.py
   args:

--- a/examples/ny-tlc-report-external-dependencies.yaml
+++ b/examples/ny-tlc-report-external-dependencies.yaml
@@ -6,9 +6,11 @@ metadata:
   namespace: default
 spec:
   version: "1.0"
-  sparkImage: docker.stackable.tech/stackable/pyspark-k8s:3.3.0-stackable0.3.0
-  # Always | IfNotPresent | Never
-  sparkImagePullPolicy: IfNotPresent
+  sparkImage:
+    custom: docker.stackable.tech/stackable/pyspark-k8s:3.3.0-stackable0.3.0
+    productVersion: "3.3.0"
+    # Always | IfNotPresent | Never
+    pullPolicy: IfNotPresent
   mode: cluster
   mainApplicationFile: s3a://my-bucket/ny_tlc_report.py
   args:

--- a/examples/ny-tlc-report-image.yaml
+++ b/examples/ny-tlc-report-image.yaml
@@ -8,8 +8,10 @@ spec:
   version: "1.0"
   # everything under /jobs will be copied to /stackable/spark/jobs
   image: docker.stackable.tech/stackable/ny-tlc-report:0.1.0
-  sparkImage: docker.stackable.tech/stackable/pyspark-k8s:3.3.0-stackable0.3.0
-  sparkImagePullPolicy: IfNotPresent
+  sparkImage:
+    custom: docker.stackable.tech/stackable/pyspark-k8s:3.3.0-stackable0.3.0
+    productVersion: "3.3.0"
+    pullPolicy: IfNotPresent
   mode: cluster
   mainApplicationFile: local:///stackable/spark/jobs/ny_tlc_report.py
   args:

--- a/examples/ny-tlc-report.yaml
+++ b/examples/ny-tlc-report.yaml
@@ -13,7 +13,9 @@ metadata:
   name: spark-ny-cm
 spec:
   version: "1.0"
-  sparkImage: docker.stackable.tech/stackable/spark-k8s:3.3.0-stackable0.3.0
+  sparkImage:
+    productVersion: "3.3.0"
+    stackableVersion: "0.3.0"
   mode: cluster
   mainApplicationFile: s3a://my-bucket/ny-tlc-report-1.1.0-3.3.0.jar
   mainClass: tech.stackable.demo.spark.NYTLCReport

--- a/rust/crd/src/constants.rs
+++ b/rust/crd/src/constants.rs
@@ -1,4 +1,5 @@
 pub const APP_NAME: &str = "spark-k8s";
+pub const DOCKER_SPARK_IMAGE_BASE_NAME: &str = "spark-k8s";
 
 pub const VOLUME_MOUNT_NAME_POD_TEMPLATES: &str = "pod-template";
 pub const VOLUME_MOUNT_PATH_POD_TEMPLATES: &str = "/stackable/spark/pod-templates";

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -136,7 +136,7 @@ pub struct SparkApplicationSpec {
     pub main_application_file: Option<String>,
     /// An external / custom image to provide extra data or libraries
     /// This should always be `CustomImage` as described in
-    /// https://docs.stackable.tech/home/nightly/concepts/product_image_selection.html#_custom_images.
+    /// `<https://docs.stackable.tech/home/nightly/concepts/product_image_selection.html#_custom_images>`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub image: Option<ProductImage>,
     /// The Spark image to use
@@ -741,7 +741,9 @@ metadata:
   name: spark-examples-s3
 spec:
   version: "1.0"
-  sparkImage: docker.stackable.tech/stackable/spark-k8s:3.2.1-hadoop3.2-python39-aws1.11.375-stackable0.3.0
+  sparkImage:
+    productVersion: 3.2.1-hadoop3.2-python39-aws1.11.375
+    stackableVersion: 0.3.0
   mode: cluster
   mainClass: org.apache.spark.examples.SparkPi
   mainApplicationFile: s3a://stackable-spark-k8s-jars/jobs/spark-examples_2.12-3.2.1.jar
@@ -796,8 +798,12 @@ metadata:
   namespace: my-ns
 spec:
   version: "1.0"
-  image: docker.stackable.tech/stackable/ny-tlc-report:0.1.0
-  sparkImage: docker.stackable.tech/stackable/spark-k8s:3.2.1-hadoop3.2-python39-aws1.11.375-stackable0.3.0
+  image:
+    custom: docker.stackable.tech/stackable/ny-tlc-report:0.1.0
+    productVersion: 0.1.0 
+  sparkImage:
+    productVersion: 3.2.1-hadoop3.2-python39-aws1.11.375
+    stackableVersion: 0.3.0
   mode: cluster
   mainApplicationFile: local:///stackable/spark/jobs/ny_tlc_report.py
   args:
@@ -851,7 +857,9 @@ metadata:
   uid: 12345678asdfghj
 spec:
   version: "1.0"
-  sparkImage: docker.stackable.tech/stackable/spark-k8s:3.2.1-hadoop3.2-python39-aws1.11.375-stackable0.3.0
+  sparkImage:
+    productVersion: 3.2.1-hadoop3.2-python39-aws1.11.375
+    stackableVersion: 0.3.0
   mode: cluster
   mainApplicationFile: s3a://stackable-spark-k8s-jars/jobs/ny_tlc_report.py
   args:

--- a/rust/operator-binary/src/spark_k8s_controller.rs
+++ b/rust/operator-binary/src/spark_k8s_controller.rs
@@ -163,7 +163,7 @@ pub async fn reconcile(spark_application: Arc<SparkApplication>, ctx: Arc<Ctx>) 
         let resolved_job_image = job_image.resolve("");
 
         // In case the job image has different pull secrets than the spark image
-        // (which have to be added to the PodSpec later), lets merge this here.
+        // (which have to be added to the PodSpec later), lets retrieve this here.
         job_image_pull_secrets = resolved_job_image.pull_secrets.clone();
 
         jcb.image_from_product_image(&resolved_job_image)

--- a/tests/templates/kuttl/pyspark-ny-public-s3-image/10-deploy-spark-app.yaml.j2
+++ b/tests/templates/kuttl/pyspark-ny-public-s3-image/10-deploy-spark-app.yaml.j2
@@ -7,8 +7,10 @@ spec:
   version: "1.0"
   # everything under /jobs will be copied to /stackable/spark/jobs
   image: docker.stackable.tech/stackable/ny-tlc-report:{{ test_scenario['values']['ny-tlc-report'] }}
-  sparkImage: docker.stackable.tech/stackable/pyspark-k8s:{{ test_scenario['values']['spark'] }}-stackable{{ test_scenario['values']['stackable'] }}
-  sparkImagePullPolicy: IfNotPresent
+  sparkImage:
+    custom: docker.stackable.tech/stackable/pyspark-k8s:{{ test_scenario['values']['spark'] }}-stackable{{ test_scenario['values']['stackable'] }}
+    productVersion: {{ test_scenario['values']['spark'] }}
+    pullPolicy: IfNotPresent
   mode: cluster
   mainApplicationFile: local:///stackable/spark/jobs/ny_tlc_report.py
   args:

--- a/tests/templates/kuttl/pyspark-ny-public-s3-image/10-deploy-spark-app.yaml.j2
+++ b/tests/templates/kuttl/pyspark-ny-public-s3-image/10-deploy-spark-app.yaml.j2
@@ -6,7 +6,9 @@ metadata:
 spec:
   version: "1.0"
   # everything under /jobs will be copied to /stackable/spark/jobs
-  image: docker.stackable.tech/stackable/ny-tlc-report:{{ test_scenario['values']['ny-tlc-report'] }}
+  image:
+    custom: docker.stackable.tech/stackable/ny-tlc-report:{{ test_scenario['values']['ny-tlc-report'] }}
+    productVersion: {{ test_scenario['values']['ny-tlc-report'] }}
   sparkImage:
     custom: docker.stackable.tech/stackable/pyspark-k8s:{{ test_scenario['values']['spark'] }}-stackable{{ test_scenario['values']['stackable'] }}
     productVersion: {{ test_scenario['values']['spark'] }}

--- a/tests/templates/kuttl/pyspark-ny-public-s3/10-deploy-spark-app.yaml.j2
+++ b/tests/templates/kuttl/pyspark-ny-public-s3/10-deploy-spark-app.yaml.j2
@@ -5,9 +5,10 @@ metadata:
   name: pyspark-ny-public-s3
 spec:
   version: "1.0"
-  # everything under /jobs will be copied to /stackable/spark/jobs
-  sparkImage: docker.stackable.tech/stackable/pyspark-k8s:{{ test_scenario['values']['spark'] }}-stackable{{ test_scenario['values']['stackable'] }}
-  sparkImagePullPolicy: IfNotPresent
+  sparkImage:
+    custom: docker.stackable.tech/stackable/pyspark-k8s:{{ test_scenario['values']['spark'] }}-stackable{{ test_scenario['values']['stackable'] }}
+    productVersion: {{ test_scenario['values']['spark'] }}
+    pullPolicy: IfNotPresent
   mode: cluster
   mainApplicationFile: s3a://my-bucket/ny_tlc_report.py
   args:

--- a/tests/templates/kuttl/resources/10-deploy-spark-app.yaml.j2
+++ b/tests/templates/kuttl/resources/10-deploy-spark-app.yaml.j2
@@ -5,7 +5,9 @@ metadata:
   name: resources-crd
 spec:
   version: "1.0"
-  sparkImage: docker.stackable.tech/stackable/pyspark-k8s:{{ test_scenario['values']['spark'] }}-stackable{{ test_scenario['values']['stackable'] }}
+  sparkImage:
+    custom: docker.stackable.tech/stackable/pyspark-k8s:{{ test_scenario['values']['spark'] }}-stackable{{ test_scenario['values']['stackable'] }}
+    productVersion: {{ test_scenario['values']['spark'] }}
   mode: cluster
   mainApplicationFile: local:///stackable/spark/examples/src/main/python/streaming/hdfs_wordcount.py
   args:

--- a/tests/templates/kuttl/resources/12-deploy-spark-app.yaml.j2
+++ b/tests/templates/kuttl/resources/12-deploy-spark-app.yaml.j2
@@ -5,7 +5,9 @@ metadata:
   name: resources-sparkconf
 spec:
   version: "1.0"
-  sparkImage: docker.stackable.tech/stackable/pyspark-k8s:{{ test_scenario['values']['spark'] }}-stackable{{ test_scenario['values']['stackable'] }}
+  sparkImage:
+    custom: docker.stackable.tech/stackable/pyspark-k8s:{{ test_scenario['values']['spark'] }}-stackable{{ test_scenario['values']['stackable'] }}
+    productVersion: {{ test_scenario['values']['spark'] }}
   mode: cluster
   mainApplicationFile: local:///stackable/spark/examples/src/main/python/streaming/hdfs_wordcount.py
   args:

--- a/tests/templates/kuttl/resources/14-deploy-spark-app.yaml.j2
+++ b/tests/templates/kuttl/resources/14-deploy-spark-app.yaml.j2
@@ -5,7 +5,9 @@ metadata:
   name: resources-defaults
 spec:
   version: "1.0"
-  sparkImage: docker.stackable.tech/stackable/pyspark-k8s:{{ test_scenario['values']['spark'] }}-stackable{{ test_scenario['values']['stackable'] }}
+  sparkImage:
+    custom: docker.stackable.tech/stackable/pyspark-k8s:{{ test_scenario['values']['spark'] }}-stackable{{ test_scenario['values']['stackable'] }}
+    productVersion: {{ test_scenario['values']['spark'] }}
   mode: cluster
   mainApplicationFile: local:///stackable/spark/examples/src/main/python/streaming/hdfs_wordcount.py
   args:

--- a/tests/templates/kuttl/spark-examples/10-deploy-spark-app.yaml.j2
+++ b/tests/templates/kuttl/spark-examples/10-deploy-spark-app.yaml.j2
@@ -5,8 +5,10 @@ metadata:
   name: spark-examples
 spec:
   version: "1.0"
-  sparkImage: docker.stackable.tech/stackable/spark-k8s:{{ test_scenario['values']['spark'] }}-stackable{{ test_scenario['values']['stackable'] }}
-  sparkImagePullPolicy: IfNotPresent
+  sparkImage:
+    productVersion: {{ test_scenario['values']['spark'] }}
+    stackableVersion: {{ test_scenario['values']['stackable'] }}
+    pullPolicy: IfNotPresent
   mode: cluster
   mainClass: org.apache.spark.examples.SparkALS
   mainApplicationFile: local:///stackable/spark/examples/jars/spark-examples_2.12-{{ test_scenario['values']['spark'] }}.jar

--- a/tests/templates/kuttl/spark-ny-public-s3/10-deploy-spark-app.yaml.j2
+++ b/tests/templates/kuttl/spark-ny-public-s3/10-deploy-spark-app.yaml.j2
@@ -13,8 +13,10 @@ metadata:
   name: spark-ny-cm
 spec:
   version: "1.0"
-  sparkImage: docker.stackable.tech/stackable/spark-k8s:{{ test_scenario['values']['spark'] }}-stackable{{ test_scenario['values']['stackable'] }}
-  sparkImagePullPolicy: IfNotPresent
+  sparkImage:
+    productVersion: {{ test_scenario['values']['spark'] }}
+    stackableVersion: {{ test_scenario['values']['stackable'] }}
+    pullPolicy: IfNotPresent
   mode: cluster
   mainClass: tech.stackable.demo.spark.NYTLCReport
   mainApplicationFile: s3a://my-bucket/ny-tlc-report-1.1.0-{{ test_scenario['values']['spark'] }}.jar

--- a/tests/templates/kuttl/spark-pi-private-s3/10-deploy-spark-app.yaml.j2
+++ b/tests/templates/kuttl/spark-pi-private-s3/10-deploy-spark-app.yaml.j2
@@ -5,8 +5,10 @@ metadata:
   name: spark-pi-private-s3
 spec:
   version: "1.0"
-  sparkImage: docker.stackable.tech/stackable/spark-k8s:{{ test_scenario['values']['spark'] }}-stackable{{ test_scenario['values']['stackable'] }}
-  sparkImagePullPolicy: IfNotPresent
+  sparkImage:
+    productVersion: {{ test_scenario['values']['spark'] }}
+    stackableVersion: {{ test_scenario['values']['stackable'] }}
+    pullPolicy: IfNotPresent
   mode: cluster
   mainClass: org.apache.spark.examples.SparkPi
   mainApplicationFile: s3a://my-bucket/spark-examples_2.12-{{ test_scenario['values']['spark'] }}.jar

--- a/tests/templates/kuttl/spark-pi-public-s3/10-deploy-spark-app.yaml.j2
+++ b/tests/templates/kuttl/spark-pi-public-s3/10-deploy-spark-app.yaml.j2
@@ -5,8 +5,10 @@ metadata:
   name: spark-pi-public-s3
 spec:
   version: "1.0"
-  sparkImage: docker.stackable.tech/stackable/spark-k8s:{{ test_scenario['values']['spark'] }}-stackable{{ test_scenario['values']['stackable'] }}
-  sparkImagePullPolicy: IfNotPresent
+  sparkImage:
+    productVersion: {{ test_scenario['values']['spark'] }}
+    stackableVersion: {{ test_scenario['values']['stackable'] }}
+    pullPolicy: IfNotPresent
   mode: cluster
   mainClass: org.apache.spark.examples.SparkPi
   mainApplicationFile: s3a://my-bucket/spark-examples_2.12-{{ test_scenario['values']['spark'] }}.jar


### PR DESCRIPTION
# Description

fixes https://github.com/stackabletech/spark-k8s-operator/issues/185

@razvan @adwk67 Im not sure if this makes sense as is. The `spec.sparkImage` along with the `spec.sparkPullPolicy` etc. was replaced with the Product image selection. I adapted the tests (did not touch the docs yet).

What about the `spec.image`? 

The product image selection was not required here anyways, it worked "offline" before out of the box. I just tried to consolidate this.

What do you think?

test: https://ci.stackable.tech/view/02%20Operator%20Tests%20(custom)/job/spark-k8s-operator-it-custom/49/

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] CRD change approved (or not applicable)
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
