### PR TITLE
[Merged by Bors] - run as root group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ All notable changes to this project will be documented in this file.
 - `operator-rs` `0.38.0` -> `0.41.0` ([#235]).
 - Use 0.0.0-dev product images for testing ([#236])
 - Use testing-tools 0.2.0 ([#236])
+- Run as root group ([#236]).
 
 [#235]: https://github.com/stackabletech/spark-k8s-operator/pull/235
 [#236]: https://github.com/stackabletech/spark-k8s-operator/pull/236
 [#238]: https://github.com/stackabletech/spark-k8s-operator/pull/238
+[#241]: https://github.com/stackabletech/spark-k8s-operator/pull/241
 
 ## [23.4.0] - 2023-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 - `operator-rs` `0.38.0` -> `0.41.0` ([#235]).
 - Use 0.0.0-dev product images for testing ([#236])
 - Use testing-tools 0.2.0 ([#236])
-- Run as root group ([#236]).
+- Run as root group ([#241]).
 
 [#235]: https://github.com/stackabletech/spark-k8s-operator/pull/235
 [#236]: https://github.com/stackabletech/spark-k8s-operator/pull/236

--- a/rust/crd/src/constants.rs
+++ b/rust/crd/src/constants.rs
@@ -51,3 +51,4 @@ pub const HISTORY_CONFIG_FILE_NAME: &str = "spark-defaults.conf";
 pub const HISTORY_CONFIG_FILE_NAME_FULL: &str = "/stackable/spark/conf/spark-defaults.conf";
 
 pub const SPARK_CLUSTER_ROLE: &str = "spark-k8s-clusterrole";
+pub const SPARK_UID: i64 = 1000;

--- a/rust/operator-binary/src/history_controller.rs
+++ b/rust/operator-binary/src/history_controller.rs
@@ -347,8 +347,8 @@ fn build_stateful_set(
             ))
         })
         .security_context(PodSecurityContext {
-            run_as_user: Some(1000),
-            run_as_group: Some(1000),
+            run_as_user: Some(SPARK_UID),
+            run_as_group: Some(0),
             fs_group: Some(1000),
             ..PodSecurityContext::default()
         });

--- a/rust/operator-binary/src/spark_k8s_controller.rs
+++ b/rust/operator-binary/src/spark_k8s_controller.rs
@@ -747,8 +747,8 @@ fn build_spark_role_serviceaccount(
 
 fn security_context() -> PodSecurityContext {
     PodSecurityContext {
-        run_as_user: Some(1000),
-        run_as_group: Some(1000),
+        run_as_user: Some(SPARK_UID),
+        run_as_group: Some(0),
         fs_group: Some(1000),
         ..PodSecurityContext::default()
     }


### PR DESCRIPTION
# Description

run as root group instead of 1000.

Tests on openshift:

```
--- PASS: kuttl (624.59s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/spark-pi-private-s3_openshift-true_spark-3.3.0-stackable0.0.0-dev_examples-3.3.0 (119.82s)
        --- PASS: kuttl/harness/spark-history-server_openshift-true_spark-3.3.0-stackable0.0.0-dev_examples-3.3.0 (206.96s)
        --- PASS: kuttl/harness/pyspark-ny-public-s3_openshift-true_spark-3.3.0-stackable0.0.0-dev (137.54s)
        --- PASS: kuttl/harness/spark-ny-public-s3_openshift-true_spark-3.3.0-stackable0.0.0-dev_examples-3.3.0 (85.56s)
        --- PASS: kuttl/harness/spark-examples_openshift-true_spark-3.3.0-stackable0.0.0-dev_examples-3.3.0 (42.68s)
        --- PASS: kuttl/harness/pyspark-ny-public-s3-image_openshift-true_spark-3.3.0-stackable0.0.0-dev_ny-tlc-report-0.1.0 (93.64s)
        --- PASS: kuttl/harness/spark-pi-public-s3_openshift-true_spark-3.3.0-stackable0.0.0-dev_examples-3.3.0 (73.82s)
        --- PASS: kuttl/harness/logging_openshift-true_spark-3.3.0-stackable0.0.0-dev_ny-tlc-report-0.1.0_examples-3.3.0 (287.47s)
        --- PASS: kuttl/harness/resources_openshift-true_spark-3.3.0-stackable0.0.0-dev_examples-3.3.0 (110.78s)
PASS
```


<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
