### PR TITLE
Executors don't resolve dependencies

### DIFF
--- a/rust/crd/src/constants.rs
+++ b/rust/crd/src/constants.rs
@@ -1,5 +1,8 @@
 pub const APP_NAME: &str = "spark-k8s";
 
+pub const VOLUME_MOUNT_NAME_IVY2: &str = "ivy2";
+pub const VOLUME_MOUNT_PATH_IVY2: &str = "/ivy2";
+
 pub const VOLUME_MOUNT_NAME_DRIVER_POD_TEMPLATES: &str = "driver-pod-template";
 pub const VOLUME_MOUNT_PATH_DRIVER_POD_TEMPLATES: &str = "/stackable/spark/driver-pod-templates";
 

--- a/tests/templates/kuttl/postgresql/00-assert.yaml
+++ b/tests/templates/kuttl/postgresql/00-assert.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 900
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: integration-tests-sa
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: spark-postgresql
+status:
+  readyReplicas: 1
+  replicas: 1

--- a/tests/templates/kuttl/postgresql/00-install-postgresql.yaml
+++ b/tests/templates/kuttl/postgresql/00-install-postgresql.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: >-
+      helm install spark-postgresql
+      --namespace $NAMESPACE
+      --version 12.1.5
+      -f helm-bitnami-postgresql-values.yaml
+      --repo https://charts.bitnami.com/bitnami postgresql
+    timeout: 600

--- a/tests/templates/kuttl/postgresql/00-serviceaccount.yaml.j2
+++ b/tests/templates/kuttl/postgresql/00-serviceaccount.yaml.j2
@@ -1,0 +1,29 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: use-integration-tests-scc
+rules:
+{% if test_scenario['values']['openshift'] == "true" %}
+  - apiGroups: ["security.openshift.io"]
+    resources: ["securitycontextconstraints"]
+    resourceNames: ["privileged"]
+    verbs: ["use"]
+{% endif %}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: integration-tests-sa
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: use-integration-tests-scc
+subjects:
+  - kind: ServiceAccount
+    name: integration-tests-sa
+roleRef:
+  kind: Role
+  name: use-integration-tests-scc
+  apiGroup: rbac.authorization.k8s.io

--- a/tests/templates/kuttl/postgresql/01-assert.yaml.j2
+++ b/tests/templates/kuttl/postgresql/01-assert.yaml.j2
@@ -1,0 +1,10 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+{% if lookup('env', 'VECTOR_AGGREGATOR') %}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vector-aggregator-discovery
+{% endif %}

--- a/tests/templates/kuttl/postgresql/01-install-vector-aggregator-discovery-configmap.yaml.j2
+++ b/tests/templates/kuttl/postgresql/01-install-vector-aggregator-discovery-configmap.yaml.j2
@@ -1,0 +1,9 @@
+{% if lookup('env', 'VECTOR_AGGREGATOR') %}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vector-aggregator-discovery
+data:
+  ADDRESS: {{ lookup('env', 'VECTOR_AGGREGATOR') }}
+{% endif %}

--- a/tests/templates/kuttl/postgresql/10-assert.yaml
+++ b/tests/templates/kuttl/postgresql/10-assert.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 900
+---
+# The Job starting the whole process
+apiVersion: spark.stackable.tech/v1alpha1
+kind: SparkApplication
+metadata:
+  name: spark-examples
+status:
+  phase: Succeeded

--- a/tests/templates/kuttl/postgresql/10-deploy-spark-app.yaml.j2
+++ b/tests/templates/kuttl/postgresql/10-deploy-spark-app.yaml.j2
@@ -1,0 +1,56 @@
+---
+apiVersion: spark.stackable.tech/v1alpha1
+kind: SparkApplication
+metadata:
+  name: spark-examples
+spec:
+  version: "1.0"
+{% if lookup('env', 'VECTOR_AGGREGATOR') %}
+  vectorAggregatorConfigMapName: vector-aggregator-discovery
+{% endif %}
+  sparkImage: "docker.stackable.tech/stackable/pyspark-k8s:{{ test_scenario['values']['spark-latest'].split('-stackable')[0] }}-stackable{{ test_scenario['values']['spark-latest'].split('-stackable')[1] }}"
+  sparkImagePullPolicy: IfNotPresent
+  mode: cluster
+  mainApplicationFile: "local:///stackable/spark/jobs/write-to-postgresql.py"
+  job:
+    logging:
+      enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
+  driver:
+    logging:
+      enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
+    volumeMounts:
+      - name: script
+        mountPath: /stackable/spark/jobs
+  executor:
+    instances: 1
+    logging:
+      enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
+    volumeMounts:
+      - name: script
+        mountPath: /stackable/spark/jobs
+  deps:
+    packages:
+      - org.postgresql:postgresql:42.6.0
+  volumes:
+    - name: script
+      configMap:
+        name: write-to-postgresql
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: write-to-postgresql
+data:
+  write-to-postgresql.py: |
+    from pyspark.sql import SparkSession
+    from pyspark.sql.types import *
+
+    spark = SparkSession.builder.appName("write-to-postgresql").getOrCreate()
+
+    df = spark.createDataFrame([1,2,3], IntegerType())
+    
+    # Specifying create table column data types on write
+    df.write \
+    .option("createTableColumnTypes", "value INTEGER") \
+    .jdbc("jdbc:postgresql://spark-postgresql/spark", "sparktest",
+          properties={"user": "spark", "password": "spark"})

--- a/tests/templates/kuttl/postgresql/helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/postgresql/helm-bitnami-postgresql-values.yaml.j2
@@ -1,0 +1,24 @@
+---
+volumePermissions:
+  enabled: false
+  securityContext:
+    runAsUser: auto
+
+primary:
+  podSecurityContext:
+{% if test_scenario['values']['openshift'] == 'true' %}
+    enabled: false
+{% else %}
+    enabled: true
+{% endif %}
+  containerSecurityContext:
+    enabled: false
+
+shmVolume:
+  chmod:
+    enabled: false
+
+auth:
+  username: spark
+  password: spark
+  database: spark

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -14,6 +14,12 @@ dimensions:
   - name: ny-tlc-report
     values:
       - 0.1.0
+  - name: spark-latest
+    values:
+      - 3.4.0-stackable0.0.0-dev
+  - name: postgresql
+    values:
+      - 42.6.0
 tests:
   - name: spark-history-server
     dimensions:
@@ -52,4 +58,9 @@ tests:
     dimensions:
       - spark
       - ny-tlc-report
+      - openshift
+  - name: postgresql
+    dimensions:
+      - spark-latest
+      - postgresql
       - openshift


### PR DESCRIPTION
Fixes https://github.com/stackabletech/spark-k8s-operator/issues/141

This PR tests is Spark can load `--packages` in Kubernetes clusters (drivers **and** executors). It uses the PostgreSQL JDBC driver and Spark  3.4.0 as an example.

It currently fails to load the JDBC driver in the Spark driver:

```
2023-05-31T08:44:21,700 INFO [Thread-4] org.sparkproject.jetty.server.handler.ContextHandler - Started o.s.j.s.ServletContextHandler@354a8809{/static/sql,null,AVAILABLE,@Spark}
Traceback (most recent call last):
  File "/stackable/spark/jobs/write-to-postgresql.py", line 11, in <module>
    .jdbc("jdbc:postgresql://spark-postgresql/spark", "sparktest",
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/stackable/spark/python/lib/pyspark.zip/pyspark/sql/readwriter.py", line 1919, in jdbc
  File "/stackable/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/java_gateway.py", line 1322, in __call__
  File "/stackable/spark/python/lib/pyspark.zip/pyspark/errors/exceptions/captured.py", line 169, in deco
  File "/stackable/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/protocol.py", line 326, in get_return_value
py4j.protocol.Py4JJavaError: An error occurred while calling o76.jdbc.
: java.sql.SQLException: No suitable driver
        at java.sql/java.sql.DriverManager.getDriver(DriverManager.java:298)
```