### PR TITLE
[Merged by Bors] - Added kuttl test suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Use 0.0.0-dev product images for testing ([#236])
 - Use testing-tools 0.2.0 ([#236])
 - Run as root group ([#241]).
+- Added kuttl test suites ([#252])
 
 ### Fixed
 
@@ -28,6 +29,7 @@ All notable changes to this project will be documented in this file.
 [#241]: https://github.com/stackabletech/spark-k8s-operator/pull/241
 [#243]: https://github.com/stackabletech/spark-k8s-operator/pull/243
 [#247]: https://github.com/stackabletech/spark-k8s-operator/pull/247
+[#252]: https://github.com/stackabletech/spark-k8s-operator/pull/252
 
 ## [23.4.0] - 2023-04-17
 

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -65,3 +65,18 @@ tests:
       - spark
       - ny-tlc-report
       - openshift
+suites:
+  - name: latest
+    patch:
+      - dimensions:
+          - expr: last
+  - name: smoke
+    select:
+      - smoke
+  - name: openshift
+    patch:
+      - dimensions:
+          - expr: last
+      - dimensions:
+          - name: openshift
+            expr: "true"


### PR DESCRIPTION

# Description

Requires `beku 0.0.7`. Upgrade with:

```
pip install --upgrade beku-stackabletech
```

Added three test suites:

* `latest` : only run tests with the latest versions.
* `smoke` : only run smoke tests.
* `openshift` : only run latest versions with openshift=true.

To  run the `latest` test suite:

```
rm -rf tests/_work && beku -s latest
```

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [x] Code contains useful comments
- [x] (Integration-)Test cases added
- [x] Documentation added or updated
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
