### PR TITLE
[Merged by Bors] - fix: Typo in executor cpu limit property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fix quoting issues when spark config values contain spaces ([#243]).
-- Increase the size limit of log volumes (#[259]).
-- Typo in executor cpu limit property (#[263]).
+- Increase the size limit of log volumes ([#259]).
+- Typo in executor cpu limit property ([#263]).
 
 [#235]: https://github.com/stackabletech/spark-k8s-operator/pull/235
 [#236]: https://github.com/stackabletech/spark-k8s-operator/pull/236

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,20 +13,21 @@ All notable changes to this project will be documented in this file.
 - Add support for using custom certificates when accessing S3 with TLS ([#247]).
 - Use bitnami charts for testing S3 access with TLS ([#247]).
 - Set explicit resources on all containers ([#249]).
-- Support pod overrides ([#256])
+- Support pod overrides ([#256]).
 
 ### Changed
 
 - `operator-rs` `0.38.0` -> `0.44.0` ([#235], [#259]).
-- Use 0.0.0-dev product images for testing ([#236])
-- Use testing-tools 0.2.0 ([#236])
+- Use 0.0.0-dev product images for testing ([#236]).
+- Use testing-tools 0.2.0 ([#236]).
 - Run as root group ([#241]).
-- Added kuttl test suites ([#252])
+- Added kuttl test suites ([#252]).
 
 ### Fixed
 
 - Fix quoting issues when spark config values contain spaces ([#243]).
-- Increase the size limit of log volumes (#[259])
+- Increase the size limit of log volumes (#[259]).
+- Typo in executor cpu limit property (#[263]).
 
 [#235]: https://github.com/stackabletech/spark-k8s-operator/pull/235
 [#236]: https://github.com/stackabletech/spark-k8s-operator/pull/236
@@ -38,6 +39,7 @@ All notable changes to this project will be documented in this file.
 [#249]: https://github.com/stackabletech/spark-k8s-operator/pull/249
 [#256]: https://github.com/stackabletech/spark-k8s-operator/pull/256
 [#259]: https://github.com/stackabletech/spark-k8s-operator/pull/259
+[#263]: https://github.com/stackabletech/spark-k8s-operator/pull/263
 
 ## [23.4.0] - 2023-04-17
 

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -813,7 +813,7 @@ fn resources_to_executor_props(
             "spark.kubernetes.executor.request.cores".to_string(),
             cores.clone(),
         );
-        props.insert("spark.kubernetes.executors.limit.cores".to_string(), cores);
+        props.insert("spark.kubernetes.executor.limit.cores".to_string(), cores);
     }
 
     if let Resources {
@@ -1532,7 +1532,7 @@ spec:
                 "512m".to_string(),
             ),
             (
-                "spark.kubernetes.executors.limit.cores".to_string(),
+                "spark.kubernetes.executor.limit.cores".to_string(),
                 "2".to_string(),
             ),
         ]

--- a/tests/templates/kuttl/resources/10-assert.yaml.j2
+++ b/tests/templates/kuttl/resources/10-assert.yaml.j2
@@ -36,10 +36,10 @@ spec:
       resources:
       # these resources are set via Spark submit properties like "spark.driver.cores"
         limits:
-          cpu: "1"
+          cpu: "2"
           memory: 1Gi
         requests:
-          cpu: "1"
+          cpu: "2"
           memory: 1Gi
 ---
 apiVersion: v1

--- a/tests/templates/kuttl/resources/10-deploy-spark-app.yaml.j2
+++ b/tests/templates/kuttl/resources/10-deploy-spark-app.yaml.j2
@@ -31,7 +31,7 @@ spec:
     resources:
       cpu:
         min: 200m
-        max: 1000m
+        max: 1200m
       memory:
         limit: 1024Mi
   executor:


### PR DESCRIPTION
# Description

Introduced in https://github.com/stackabletech/spark-k8s-operator/pull/256

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
