### PR TITLE
Revert test changes that broke tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Default stackableVersion to operator version. It is recommended to remove `spec.image.stackableVersion` from your custom resources ([#267], [#XXX]).
+- Default stackableVersion to operator version. It is recommended to remove `spec.image.stackableVersion` from your custom resources ([#267], [#268]).
 
 [#267]: https://github.com/stackabletech/spark-k8s-operator/pull/267
+[#268]: https://github.com/stackabletech/spark-k8s-operator/pull/268
 
 ## [23.7.0] - 2023-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Default stackableVersion to operator version. It is recommended to remove `spec.image.stackableVersion` from your custom resources ([#267]).
+- Default stackableVersion to operator version. It is recommended to remove `spec.image.stackableVersion` from your custom resources ([#267], [#XXX]).
 
 [#267]: https://github.com/stackabletech/spark-k8s-operator/pull/267
 

--- a/tests/templates/kuttl/logging/04-deploy-history-server.yaml.j2
+++ b/tests/templates/kuttl/logging/04-deploy-history-server.yaml.j2
@@ -22,7 +22,8 @@ metadata:
   name: spark-history
 spec:
   image:
-    productVersion: "{{ test_scenario['values']['spark'] }}"
+    productVersion: "{{ test_scenario['values']['spark'].split('-stackable')[0] }}"
+    stackableVersion: "{{ test_scenario['values']['spark'].split('-stackable')[1] }}"
   vectorAggregatorConfigMapName: spark-vector-aggregator-discovery
   logFileDirectory:
     s3:

--- a/tests/templates/kuttl/pod_overrides/06-deploy-history-server.yaml.j2
+++ b/tests/templates/kuttl/pod_overrides/06-deploy-history-server.yaml.j2
@@ -25,7 +25,8 @@ metadata:
   name: spark-history
 spec:
   image:
-    productVersion: "{{ test_scenario['values']['spark'] }}"
+    productVersion: "{{ test_scenario['values']['spark'].split('-stackable')[0] }}"
+    stackableVersion: "{{ test_scenario['values']['spark'].split('-stackable')[1] }}"
   logFileDirectory:
     s3:
       prefix: eventlogs/

--- a/tests/templates/kuttl/smoke/06-deploy-history-server.yaml.j2
+++ b/tests/templates/kuttl/smoke/06-deploy-history-server.yaml.j2
@@ -25,7 +25,8 @@ metadata:
   name: spark-history
 spec:
   image:
-    productVersion: "{{ test_scenario['values']['spark'] }}"
+    productVersion: "{{ test_scenario['values']['spark'].split('-stackable')[0] }}"
+    stackableVersion: "{{ test_scenario['values']['spark'].split('-stackable')[1] }}"
 {% if lookup('env', 'VECTOR_AGGREGATOR') %}
   vectorAggregatorConfigMapName: vector-aggregator-discovery
 {% endif %}

--- a/tests/templates/kuttl/spark-history-server/06-deploy-history-server.yaml.j2
+++ b/tests/templates/kuttl/spark-history-server/06-deploy-history-server.yaml.j2
@@ -25,7 +25,8 @@ metadata:
   name: spark-history
 spec:
   image:
-    productVersion: "{{ test_scenario['values']['spark'] }}"
+    productVersion: "{{ test_scenario['values']['spark'].split('-stackable')[0] }}"
+    stackableVersion: "{{ test_scenario['values']['spark'].split('-stackable')[1] }}"
 {% if lookup('env', 'VECTOR_AGGREGATOR') %}
   vectorAggregatorConfigMapName: vector-aggregator-discovery
 {% endif %}

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -15,8 +15,8 @@ dimensions:
       - "false"
   - name: spark
     values:
-      - 3.3.0
-      - 3.4.0
+      - 3.3.0-stackable0.0.0-dev
+      - 3.4.0-stackable0.0.0-dev
   - name: ny-tlc-report
     values:
       - 0.1.0


### PR DESCRIPTION
# Description

Fixup of #267

spark-k8s op is different here, as it requires the full image name instead of the `spec.image` struct. So we can't omit the stackableVersion here. We *could* omit it for the HistoryServer, but that does not really improve things.


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
