### PR TITLE
tests: added namespace patch for openshift tests

### DIFF
--- a/tests/release.yaml
+++ b/tests/release.yaml
@@ -1,7 +1,7 @@
 # Contains all operators required to run the test suite.
 ---
 releases:
-  # Do not change the name of the release as it's referenced from run_tests.sh
+  # Do not change the name of the release as it's referenced from run-tests
   tests:
     releaseDate: 1970-01-01
     description: Integration test

--- a/tests/templates/kuttl/delta-lake/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/delta-lake/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/iceberg/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/iceberg/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/logging/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/logging/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/pod_overrides/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/pod_overrides/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/pyspark-ny-public-s3-image/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/pyspark-ny-public-s3-image/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/pyspark-ny-public-s3/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/pyspark-ny-public-s3/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/resources/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/resources/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/smoke/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/smoke/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/spark-examples/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/spark-examples/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/spark-history-server/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/spark-history-server/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/spark-ny-public-s3/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/spark-ny-public-s3/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/spark-pi-private-s3/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/spark-pi-private-s3/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/spark-pi-public-s3/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/spark-pi-public-s3/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -79,10 +79,12 @@ tests:
   - name: iceberg
     dimensions:
       - spark
+      - openshift
   - name: delta-lake
     dimensions:
       - spark-delta-lake
       - delta
+      - openshift
 suites:
   - name: nightly
     patch:


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/issues/issues/566.

OKD:

```
--- FAIL: kuttl (2603.56s)
    --- FAIL: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/pyspark-ny-public-s3-image_openshift-true_spark-3.5.1_ny-tlc-report-0.1.0 (257.63s)
        --- PASS: kuttl/harness/smoke_openshift-true_spark-3.5.1_s3-use-tls-true (385.79s)
        --- FAIL: kuttl/harness/delta-lake_openshift-true_spark-delta-lake-3.5.1_delta-3.1.0 (344.43s)
        --- PASS: kuttl/harness/logging_openshift-true_spark-3.5.1_ny-tlc-report-0.1.0 (655.56s)
        --- PASS: kuttl/harness/spark-history-server_openshift-true_spark-3.5.1_s3-use-tls-true (588.73s)
        --- PASS: kuttl/harness/spark-ny-public-s3_openshift-true_spark-3.5.1_s3-use-tls-true (252.34s)
        --- PASS: kuttl/harness/iceberg_openshift-true_spark-3.5.1 (235.57s)
        --- PASS: kuttl/harness/resources_openshift-true_spark-3.5.1 (104.28s)
        --- PASS: kuttl/harness/spark-pi-private-s3_openshift-true_spark-3.5.1 (831.66s)
        --- PASS: kuttl/harness/spark-pi-public-s3_openshift-true_spark-3.5.1 (616.34s)
        --- PASS: kuttl/harness/spark-examples_openshift-true_spark-3.5.1 (88.73s)
        --- PASS: kuttl/harness/pyspark-ny-public-s3_openshift-true_spark-3.5.1 (206.25s)
        --- PASS: kuttl/harness/pod_overrides_openshift-true_spark-3.5.1 (358.59s)
```

Rerun on a clean cluster:

```
--- PASS: kuttl (292.85s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/delta-lake_openshift-true_spark-delta-lake-3.5.1_delta-3.1.0 (284.58s)
```

ARO (4.13):

```
--- PASS: kuttl (268.99s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/delta-lake_openshift-true_spark-delta-lake-3.5.1_delta-3.1.0 (258.64s)
```

Azure:

```
--- PASS: kuttl (899.76s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/spark-pi-private-s3_openshift-false_spark-3.5.1 (117.69s)
        --- PASS: kuttl/harness/smoke_openshift-false_spark-3.5.1_s3-use-tls-true (162.28s)
        --- PASS: kuttl/harness/spark-examples_openshift-false_spark-3.5.1 (45.71s)
        --- PASS: kuttl/harness/delta-lake_openshift-false_spark-delta-lake-3.5.1_delta-3.1.0 (178.79s)
        --- PASS: kuttl/harness/resources_openshift-false_spark-3.5.1 (52.32s)
        --- PASS: kuttl/harness/pyspark-ny-public-s3_openshift-false_spark-3.5.1 (111.18s)
        --- PASS: kuttl/harness/spark-history-server_openshift-false_spark-3.5.1_s3-use-tls-true (253.79s)
        --- PASS: kuttl/harness/pod_overrides_openshift-false_spark-3.5.1 (105.13s)
        --- PASS: kuttl/harness/spark-ny-public-s3_openshift-false_spark-3.5.1_s3-use-tls-true (122.51s)
        --- PASS: kuttl/harness/spark-pi-public-s3_openshift-false_spark-3.5.1 (79.12s)
        --- PASS: kuttl/harness/pyspark-ny-public-s3-image_openshift-false_spark-3.5.1_ny-tlc-report-0.1.0 (104.20s)
        --- PASS: kuttl/harness/iceberg_openshift-false_spark-3.5.1 (57.58s)
        --- PASS: kuttl/harness/logging_openshift-false_spark-3.5.1_ny-tlc-report-0.1.0 (313.74s)
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [x] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
