### PR TITLE
fix: allow fine-granular resource CPU settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Update Rust dependency versions, most notably operator-rs 0.67.1 ([#401]
+- Update Rust dependency versions, most notably operator-rs 0.67.1 ([#401])
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Use actual values of resource CPU settings for pod values, but still rounding up for parallelism ([#408]).
+- BREAKING (behaviour): Specified CPU resources are now applied correctly (instead of rounding it to the next whole number).
+  This might affect your jobs, as they now e.g. only have 200m CPU resources requested instead of the 1000m it had so far,
+  meaning they might slow down significantly([#408]).
 
 [#401]: https://github.com/stackabletech/spark-k8s-operator/pull/401
 [#408]: https://github.com/stackabletech/spark-k8s-operator/pull/408

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Update Rust dependency versions, most notably operator-rs 0.67.1 ([#401])
+- Update Rust dependency versions, most notably operator-rs 0.67.1 ([#401]
+
+### Fixed
+
+- Use actual values of resource CPU settings for pod values, but still rounding up for parallelism ([#408]).
 
 [#401]: https://github.com/stackabletech/spark-k8s-operator/pull/401
+[#408]: https://github.com/stackabletech/spark-k8s-operator/pull/408
 
 ## [24.3.0] - 2024-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 
 - BREAKING (behaviour): Specified CPU resources are now applied correctly (instead of rounding it to the next whole number).
   This might affect your jobs, as they now e.g. only have 200m CPU resources requested instead of the 1000m it had so far,
-  meaning they might slow down significantly([#408]).
+  meaning they might slow down significantly ([#408]).
 
 [#401]: https://github.com/stackabletech/spark-k8s-operator/pull/401
 [#408]: https://github.com/stackabletech/spark-k8s-operator/pull/408

--- a/docs/modules/spark-k8s/pages/usage-guide/resources.adoc
+++ b/docs/modules/spark-k8s/pages/usage-guide/resources.adoc
@@ -58,26 +58,32 @@ To illustrate resource configuration consider the use-case where resources are d
 
 === CPU
 
-CPU request and limit will be rounded up to the next integer value, resulting in the following:
+CPU request and limit will be used as defined in the custom resource resulting in the following:
 
 
 |===
-|CRD |Spark conf
+|CRD |spark.kubernetes.{driver/executor} cores|spark.{driver/executor} cores (rounded up)
 
+|1800m
 |1800m
 |2
 
 |100m
+|100m
 |1
 
+|1.5
 |1.5
 |2
 
 |2
 |2
+|2
 |===
 
-Spark allows CPU limits to be set for the driver and executor using Spark settings (`spark.{driver|executor}.cores}`) as well as Kubernetes-specific ones (`spark.kubernetes.{driver,executor}.{request|limit}.cores`). `spark.kubernetes.executor.request.cores` takes precedence over `spark.executor.cores` in determining the pod CPU request, but does not affect task parallelism (the number of tasks an executor can run concurrently), so for this reason `spark.executor.cores` is set to the value of `spark.kubernetes.executor.limit.cores`.
+`spark.kubernetes.{driver,executor}.{request|limit}.cores` determine the actual pod CPU request and are taken directly from the manifest as defined by the user.
+`spark.{driver|executor}.cores}` are set to the rounded(-up) value of the manifest settings.
+Task parallelism (the number of tasks an executor can run concurrently), is determined by `spark.executor.cores`.
 
 === Memory
 

--- a/tests/templates/kuttl/resources/10-assert.yaml.j2
+++ b/tests/templates/kuttl/resources/10-assert.yaml.j2
@@ -33,10 +33,10 @@ spec:
       resources:
       # these resources are set via Spark submit properties like "spark.driver.cores"
         limits:
-          cpu: "2"
+          cpu: 1200m
           memory: 1Gi
         requests:
-          cpu: "1"
+          cpu: 300m
           memory: 1Gi
 ---
 apiVersion: v1
@@ -55,5 +55,5 @@ spec:
           cpu: "2"
           memory: 1Gi
         requests:
-          cpu: "2"
+          cpu: 1250m
           memory: 1Gi

--- a/tests/templates/kuttl/resources/10-deploy-spark-app.yaml.j2
+++ b/tests/templates/kuttl/resources/10-deploy-spark-app.yaml.j2
@@ -36,7 +36,7 @@ spec:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
       resources:
         cpu:
-          min: 200m
+          min: 300m
           max: 1200m
         memory:
           limit: 1024Mi


### PR DESCRIPTION
# Description

fixes https://github.com/stackabletech/spark-k8s-operator/issues/363.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
