### PR TITLE
Upgrading minio to latest (specific tag) for multi-architecuture

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -1,7 +1,7 @@
 
 ## Build job image
 
-    docker build -t docker.stackable.tech/stackable/ny-tlc-report:0.1.0 -t docker.stackable.tech/stackable/ny-tlc-report:latest -f apps/docker/Dockerfile apps/
+    docker build -t docker.stackable.tech/stackable/ny-tlc-report:0.2.0 -t docker.stackable.tech/stackable/ny-tlc-report:latest -f apps/docker/Dockerfile apps/
 
 ## Generate report from the public data set
 

--- a/docs/modules/spark-k8s/examples/example-sparkapp-image.yaml
+++ b/docs/modules/spark-k8s/examples/example-sparkapp-image.yaml
@@ -5,7 +5,7 @@ metadata:
   name: example-sparkapp-image
   namespace: default
 spec:
-  image: docker.stackable.tech/stackable/ny-tlc-report:0.1.0 # <1>
+  image: docker.stackable.tech/stackable/ny-tlc-report:0.2.0 # <1>
   sparkImage:
     productVersion: 3.5.1
   mode: cluster

--- a/examples/README-examples.md
+++ b/examples/README-examples.md
@@ -16,7 +16,7 @@ stackablectl operator install spark-k8s commons secret -k
 Build the `ny-tlc-report` image from the Dockerfile in this repository (apps/docker/Dockerfile) and then load it to the cluster:
 
 ````text
-kind load docker-image docker.stackable.tech/stackable/ny-tlc-report:0.1.0 --name stackable-data-platform
+kind load docker-image docker.stackable.tech/stackable/ny-tlc-report:0.2.0 --name stackable-data-platform
 ````
 
 ## Set up the `PersistentVolumeClaim`

--- a/examples/ny-tlc-report-image.yaml
+++ b/examples/ny-tlc-report-image.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
 spec:
   # everything under /jobs will be copied to /stackable/spark/jobs
-  image: docker.stackable.tech/stackable/ny-tlc-report:0.1.0
+  image: docker.stackable.tech/stackable/ny-tlc-report:0.2.0
   sparkImage: docker.stackable.tech/stackable/spark-k8s:3.5.1-stackable0.0.0-dev
   sparkImagePullPolicy: IfNotPresent
   mode: cluster

--- a/tests/templates/kuttl/delta-lake/20-setup-minio.yaml
+++ b/tests/templates/kuttl/delta-lake/20-setup-minio.yaml
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install test-minio
       --namespace $NAMESPACE
-      --version 11.9.2
+      --version 14.6.16
       -f helm-bitnami-minio-values.yaml
       --repo https://charts.bitnami.com/bitnami minio
     timeout: 240
@@ -23,7 +23,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: minio-client
-      image: docker.io/bitnami/minio-client:2022.8.11-debian-11-r3
+      image: docker.io/bitnami/minio-client:2024-debian-12
       command: ["bash", "-c", "sleep infinity"]
       stdin: true
       tty: true

--- a/tests/templates/kuttl/logging/02-setup-s3.yaml
+++ b/tests/templates/kuttl/logging/02-setup-s3.yaml
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install eventlog-minio
       --namespace $NAMESPACE
-      --version 12.2.2
+      --version 14.6.16
       -f helm-bitnami-eventlog-minio-values.yaml
       --repo https://charts.bitnami.com/bitnami minio
 ---

--- a/tests/templates/kuttl/pod_overrides/03-setup-minio.yaml
+++ b/tests/templates/kuttl/pod_overrides/03-setup-minio.yaml
@@ -5,14 +5,14 @@ commands:
   - script: >-
       helm install eventlog-minio
       --namespace $NAMESPACE
-      --version 12.6.4
+      --version 14.6.16
       -f helm-bitnami-eventlog-minio-values.yaml
       --repo https://charts.bitnami.com/bitnami minio
     timeout: 240
   - script: >-
       helm install test-minio
       --namespace $NAMESPACE
-      --version 12.6.4
+      --version 14.6.16
       -f helm-bitnami-minio-values.yaml
       --repo https://charts.bitnami.com/bitnami minio
     timeout: 240

--- a/tests/templates/kuttl/pyspark-ny-public-s3-image/02-setup-minio.yaml
+++ b/tests/templates/kuttl/pyspark-ny-public-s3-image/02-setup-minio.yaml
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install test-minio
       --namespace $NAMESPACE
-      --version 11.9.2
+      --version 14.6.16
       -f helm-bitnami-minio-values.yaml
       --repo https://charts.bitnami.com/bitnami minio
     timeout: 240
@@ -23,7 +23,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: minio-client
-      image: docker.io/bitnami/minio-client:2022.8.11-debian-11-r3
+      image: docker.io/bitnami/minio-client:2024-debian-12
       command: ["bash", "-c", "sleep infinity"]
       stdin: true
       tty: true

--- a/tests/templates/kuttl/pyspark-ny-public-s3-image/03-prepare-bucket.yaml.j2
+++ b/tests/templates/kuttl/pyspark-ny-public-s3-image/03-prepare-bucket.yaml.j2
@@ -7,5 +7,5 @@ commands:
   - command: kubectl cp -n $NAMESPACE yellow_tripdata_2021-07.csv minio-client:/tmp
   - command: kubectl exec -n $NAMESPACE minio-client -- sh -c 'mc alias set test-minio http://test-minio:9000 $$MINIO_SERVER_ACCESS_KEY $$MINIO_SERVER_SECRET_KEY'
   - command: kubectl exec -n $NAMESPACE minio-client -- mc mb test-minio/my-bucket
-  - command: kubectl exec -n $NAMESPACE minio-client -- mc policy set public test-minio/my-bucket
+  - command: kubectl exec -n $NAMESPACE minio-client -- mc anonymous set public test-minio/my-bucket
   - command: kubectl exec -n $NAMESPACE minio-client -- mc cp /tmp/yellow_tripdata_2021-07.csv test-minio/my-bucket

--- a/tests/templates/kuttl/pyspark-ny-public-s3/02-setup-minio.yaml
+++ b/tests/templates/kuttl/pyspark-ny-public-s3/02-setup-minio.yaml
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install test-minio
       --namespace $NAMESPACE
-      --version 11.9.2
+      --version 14.6.16
       -f helm-bitnami-minio-values.yaml
       --repo https://charts.bitnami.com/bitnami minio
     timeout: 240
@@ -23,7 +23,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: minio-client
-      image: docker.io/bitnami/minio-client:2022.8.11-debian-11-r3
+      image: docker.io/bitnami/minio-client:2024-debian-12
       command: ["bash", "-c", "sleep infinity"]
       stdin: true
       tty: true

--- a/tests/templates/kuttl/pyspark-ny-public-s3/03-prepare-bucket.yaml.j2
+++ b/tests/templates/kuttl/pyspark-ny-public-s3/03-prepare-bucket.yaml.j2
@@ -8,6 +8,6 @@ commands:
   - command: kubectl cp -n $NAMESPACE yellow_tripdata_2021-07.csv minio-client:/tmp
   - command: kubectl exec -n $NAMESPACE minio-client -- sh -c 'mc alias set test-minio http://test-minio:9000 $$MINIO_SERVER_ACCESS_KEY $$MINIO_SERVER_SECRET_KEY'
   - command: kubectl exec -n $NAMESPACE minio-client -- mc mb test-minio/my-bucket
-  - command: kubectl exec -n $NAMESPACE minio-client -- mc policy set public test-minio/my-bucket
+  - command: kubectl exec -n $NAMESPACE minio-client -- mc anonymous set public test-minio/my-bucket
   - command: kubectl exec -n $NAMESPACE minio-client -- mc cp /tmp/ny_tlc_report.py test-minio/my-bucket
   - command: kubectl exec -n $NAMESPACE minio-client -- mc cp /tmp/yellow_tripdata_2021-07.csv test-minio/my-bucket

--- a/tests/templates/kuttl/smoke/03-setup-minio.yaml
+++ b/tests/templates/kuttl/smoke/03-setup-minio.yaml
@@ -5,14 +5,14 @@ commands:
   - script: >-
       helm install eventlog-minio
       --namespace $NAMESPACE
-      --version 12.6.4
+      --version 14.6.16
       -f helm-bitnami-eventlog-minio-values.yaml
       --repo https://charts.bitnami.com/bitnami minio
     timeout: 240
   - script: >-
       helm install test-minio
       --namespace $NAMESPACE
-      --version 12.6.4
+      --version 14.6.16
       -f helm-bitnami-minio-values.yaml
       --repo https://charts.bitnami.com/bitnami minio
     timeout: 240

--- a/tests/templates/kuttl/spark-history-server/03-setup-minio.yaml
+++ b/tests/templates/kuttl/spark-history-server/03-setup-minio.yaml
@@ -5,14 +5,14 @@ commands:
   - script: >-
       helm install eventlog-minio
       --namespace $NAMESPACE
-      --version 12.6.4
+      --version 14.6.16
       -f helm-bitnami-eventlog-minio-values.yaml
       --repo https://charts.bitnami.com/bitnami minio
     timeout: 240
   - script: >-
       helm install test-minio
       --namespace $NAMESPACE
-      --version 12.6.4
+      --version 14.6.16
       -f helm-bitnami-minio-values.yaml
       --repo https://charts.bitnami.com/bitnami minio
     timeout: 240

--- a/tests/templates/kuttl/spark-ny-public-s3/02-setup-minio.yaml.j2
+++ b/tests/templates/kuttl/spark-ny-public-s3/02-setup-minio.yaml.j2
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install minio
       --namespace $NAMESPACE
-      --version 12.6.4
+      --version 14.6.16
       -f helm-bitnami-minio-values.yaml
       --repo https://charts.bitnami.com/bitnami minio
     timeout: 240

--- a/tests/templates/kuttl/spark-ny-public-s3/03-prepare-bucket.yaml.j2
+++ b/tests/templates/kuttl/spark-ny-public-s3/03-prepare-bucket.yaml.j2
@@ -7,9 +7,9 @@ commands:
   - command: kubectl cp -n $NAMESPACE yellow_tripdata_2021-07.csv minio-client:/tmp
   - command: kubectl cp -n $NAMESPACE ny-tlc-report-1.1.0-{{ test_scenario['values']['spark'].split(',')[0] }}.jar  minio-client:/tmp/ny-tlc-report.jar
 {% if test_scenario['values']['s3-use-tls'] == 'true' %}
-  - command: kubectl exec -n $NAMESPACE minio-client -- mc --insecure alias set minio https://minio:9000 spark sparkspark
+  - command: kubectl exec -n $NAMESPACE minio-client -- mc alias set minio https://minio:9000 spark sparkspark
 {% else %}
-  - command: kubectl exec -n $NAMESPACE minio-client -- mc --insecure alias set minio http://minio:9000 spark sparkspark
+  - command: kubectl exec -n $NAMESPACE minio-client -- mc alias set minio http://minio:9000 spark sparkspark
 {% endif %}
-  - command: kubectl exec -n $NAMESPACE minio-client -- mc --insecure cp /tmp/yellow_tripdata_2021-07.csv minio/my-bucket
-  - command: kubectl exec -n $NAMESPACE minio-client -- mc --insecure cp /tmp/ny-tlc-report.jar minio/my-bucket
+  - command: kubectl exec -n $NAMESPACE minio-client -- mc cp /tmp/yellow_tripdata_2021-07.csv minio/my-bucket
+  - command: kubectl exec -n $NAMESPACE minio-client -- mc cp /tmp/ny-tlc-report.jar minio/my-bucket

--- a/tests/templates/kuttl/spark-ny-public-s3/03-prepare-bucket.yaml.j2
+++ b/tests/templates/kuttl/spark-ny-public-s3/03-prepare-bucket.yaml.j2
@@ -7,9 +7,9 @@ commands:
   - command: kubectl cp -n $NAMESPACE yellow_tripdata_2021-07.csv minio-client:/tmp
   - command: kubectl cp -n $NAMESPACE ny-tlc-report-1.1.0-{{ test_scenario['values']['spark'].split(',')[0] }}.jar  minio-client:/tmp/ny-tlc-report.jar
 {% if test_scenario['values']['s3-use-tls'] == 'true' %}
-  - command: kubectl exec -n $NAMESPACE minio-client -- mc alias set minio https://minio:9000 spark sparkspark
+  - command: kubectl exec -n $NAMESPACE minio-client -- mc alias set --insecure  minio https://minio:9000 spark sparkspark
 {% else %}
-  - command: kubectl exec -n $NAMESPACE minio-client -- mc alias set minio http://minio:9000 spark sparkspark
+  - command: kubectl exec -n $NAMESPACE minio-client -- mc alias set --insecure minio http://minio:9000 spark sparkspark
 {% endif %}
-  - command: kubectl exec -n $NAMESPACE minio-client -- mc cp /tmp/yellow_tripdata_2021-07.csv minio/my-bucket
-  - command: kubectl exec -n $NAMESPACE minio-client -- mc cp /tmp/ny-tlc-report.jar minio/my-bucket
+  - command: kubectl exec -n $NAMESPACE minio-client -- mc --insecure cp /tmp/yellow_tripdata_2021-07.csv minio/my-bucket
+  - command: kubectl exec -n $NAMESPACE minio-client -- mc --insecure cp /tmp/ny-tlc-report.jar minio/my-bucket

--- a/tests/templates/kuttl/spark-pi-private-s3/03-setup-minio.yaml
+++ b/tests/templates/kuttl/spark-pi-private-s3/03-setup-minio.yaml
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install test-minio
       --namespace $NAMESPACE
-      --version 11.9.2
+      --version 14.6.16
       -f helm-bitnami-minio-values.yaml
       --repo https://charts.bitnami.com/bitnami minio
     timeout: 240
@@ -23,7 +23,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: minio-client
-      image: docker.io/bitnami/minio-client:2022.8.11-debian-11-r3
+      image: docker.io/bitnami/minio-client:2024-debian-12
       command: ["bash", "-c", "sleep infinity"]
       stdin: true
       tty: true

--- a/tests/templates/kuttl/spark-pi-public-s3/02-setup-minio.yaml
+++ b/tests/templates/kuttl/spark-pi-public-s3/02-setup-minio.yaml
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install test-minio
       --namespace $NAMESPACE
-      --version 11.9.2
+      --version 14.6.16
       -f helm-bitnami-minio-values.yaml
       --repo https://charts.bitnami.com/bitnami minio
     timeout: 240
@@ -23,7 +23,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: minio-client
-      image: docker.io/bitnami/minio-client:2022.8.11-debian-11-r3
+      image: docker.io/bitnami/minio-client:2024-debian-12
       command: ["bash", "-c", "sleep infinity"]
       stdin: true
       tty: true

--- a/tests/templates/kuttl/spark-pi-public-s3/03-prepare-bucket.yaml.j2
+++ b/tests/templates/kuttl/spark-pi-public-s3/03-prepare-bucket.yaml.j2
@@ -6,4 +6,4 @@ commands:
   - command: sleep 10
   - command: kubectl exec -n $NAMESPACE minio-client -- sh -c 'mc alias set test-minio http://test-minio:9000 $$MINIO_SERVER_ACCESS_KEY $$MINIO_SERVER_SECRET_KEY'
   - command: kubectl exec -n $NAMESPACE minio-client -- mc mb test-minio/my-bucket
-  - command: kubectl exec -n $NAMESPACE minio-client -- mc policy set public test-minio/my-bucket
+  - command: kubectl exec -n $NAMESPACE minio-client -- mc anonymous set public test-minio/my-bucket

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -18,7 +18,7 @@ dimensions:
       # - 3.5.1,docker.stackable.tech/sandbox/spark-k8s:3.5.1-stackable0.0.0-dev
   - name: ny-tlc-report
     values:
-      - 0.1.0
+      - 0.2.0
   - name: s3-use-tls
     values:
       - "false"


### PR DESCRIPTION
# Description

This is updating MinIO versions to newer charts and images since they now need be executable on both `amd64` and `arm64`

@adwk67 can you please check if updating versions of MinIO leads to problems on OpenShift? I would like this to be checked before we merge this :) 

Currently I run tests on our `Ampere arm64` server, I will report the status of those test. 

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [x] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
