### PR TITLE
docs: remove home module from refs (stackabletech/documentation#637) / 23.11

### DIFF
--- a/docs/modules/spark-k8s/pages/usage-guide/history-server.adoc
+++ b/docs/modules/spark-k8s/pages/usage-guide/history-server.adoc
@@ -7,7 +7,7 @@ The Stackable Spark-on-Kubernetes operator runs Apache Spark workloads in a Kube
 
 == Deployment
 
-The example below demonstrates how to set up the history server running in one Pod with scheduled cleanups of the event logs. The event logs are loaded from an S3 bucket named `spark-logs` and the folder `eventlogs/`. The credentials for this bucket are provided by the secret class `s3-credentials-class`. For more details on how the Stackable Data Platform manages S3 resources see the xref:home:concepts:s3.adoc[S3 resources] page.
+The example below demonstrates how to set up the history server running in one Pod with scheduled cleanups of the event logs. The event logs are loaded from an S3 bucket named `spark-logs` and the folder `eventlogs/`. The credentials for this bucket are provided by the secret class `s3-credentials-class`. For more details on how the Stackable Data Platform manages S3 resources see the xref:concepts:s3.adoc[S3 resources] page.
 
 
 [source,yaml]

--- a/docs/modules/spark-k8s/pages/usage-guide/resources.adoc
+++ b/docs/modules/spark-k8s/pages/usage-guide/resources.adoc
@@ -1,6 +1,6 @@
 = Resource Requests
 
-include::home:concepts:stackable_resource_requests.adoc[]
+include::concepts:stackable_resource_requests.adoc[]
 
 If no resources are configured explicitly, the operator uses the following defaults for `SparkApplication` resources:
 


### PR DESCRIPTION
# Description

docs: remove home module from refs (stackabletech/documentation#637) / 23.11