### PR TITLE
docs: remove home module from refs (stackabletech/documentation#637)

### DIFF
--- a/docs/modules/spark-k8s/pages/usage-guide/resources.adoc
+++ b/docs/modules/spark-k8s/pages/usage-guide/resources.adoc
@@ -1,6 +1,6 @@
 = Resource Requests
 
-include::home:concepts:stackable_resource_requests.adoc[]
+include::concepts:stackable_resource_requests.adoc[]
 
 If no resources are configured explicitly, the operator uses the following defaults for `SparkApplication` resources:
 


### PR DESCRIPTION
# Description

docs: remove home module from refs (stackabletech/documentation#637)