### PR TITLE
ci: fix path to ny_tlc_report script

### DIFF
--- a/apps/docker/Dockerfile
+++ b/apps/docker/Dockerfile
@@ -1,6 +1,8 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal AS builder
+# We want to automatically use the latest. We also don't tag our images with a version.
+# hadolint ignore=DL3007
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS builder
 LABEL maintainer="Stackable GmbH"
 
 WORKDIR /jobs
 
-COPY ny_tlc_report.py .
+COPY apps/ny_tlc_report.py .


### PR DESCRIPTION
# Description

Follow up of https://github.com/stackabletech/spark-k8s-operator/pull/474, there was an error in the path to the script, also some linter fixes that appear since changing the Dockerfile.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
