### PR TITLE
Adds missing KUBERNETES_CLUSTER_DOMAIN environment variable to docs

### DIFF
--- a/docs/modules/spark-k8s/pages/reference/environment-variables.adoc
+++ b/docs/modules/spark-k8s/pages/reference/environment-variables.adoc
@@ -2,13 +2,44 @@
 
 This operator accepts the following environment variables:
 
+== KUBERNETES_CLUSTER_DOMAIN
+
+*Default value*: cluster.local
+
+*Required*: false
+
+*Multiple values*: false
+
+This instructs the operator, which value it should use for the Kubernetes `clusterDomain` setting.
+Make sure to keep this in sync with whatever setting your cluster uses.
+Please see the documentation xref:guides:kubernetes-cluster-domain.adoc[on configuring the Kubernetes cluster domain] for more information on this feature.
+
+[source]
+----
+export KUBERNETES_CLUSTER_DOMAIN=mycluster.local
+cargo run -- run
+----
+
+or via docker:
+
+[source]
+----
+docker run \
+--name spark-k8s-operator \
+--network host \
+--env KUBECONFIG=/home/stackable/.kube/config \
+--env KUBERNETES_CLUSTER_DOMAIN=mycluster.local \
+--mount type=bind,source="$HOME/.kube/config",target="/home/stackable/.kube/config" \
+docker.stackable.tech/stackable/spark-k8s-operator:latest
+----
+
 == WATCH_NAMESPACE
 
 *Default value*: All namespaces
 
 *Required*: false
 
-*Multiple values:* false
+*Multiple values*: false
 
 The operator **only** watches for resources in the provided namespace `test`:
 


### PR DESCRIPTION
# Description

Adds missing KUBERNETES_CLUSTER_DOMAIN environment variable to docs

part of stackabletech/issues#668