### PR TITLE
chore(getting_started): Replace templating instructions with make

### DIFF
--- a/docs/modules/spark-k8s/examples/getting_started/getting_started.sh
+++ b/docs/modules/spark-k8s/examples/getting_started/getting_started.sh
@@ -2,17 +2,7 @@
 set -euo pipefail
 
 # DO NOT EDIT THE SCRIPT
-# Instead, update the j2 template, and regenerate it for dev:
-# cat <<EOF | jinja2 --format yaml getting_started.sh.j2 -o getting_started.sh
-# helm:
-#   repo_name: stackable-dev
-#   repo_url: https://repo.stackable.tech/repository/helm-dev/
-# versions:
-#   commons: 0.0.0-dev
-#   listener: 0.0.0-dev
-#   secret: 0.0.0-dev
-#   spark: 0.0.0-dev
-# EOF
+# Instead, update the j2 template, and regenerate it for dev with `make render-docs`.
 
 # This script contains all the code snippets from the guide, as well as some assert tests
 # to test if the instructions in the guide work. The user *could* use it, but it is intended

--- a/docs/modules/spark-k8s/examples/getting_started/getting_started.sh.j2
+++ b/docs/modules/spark-k8s/examples/getting_started/getting_started.sh.j2
@@ -2,17 +2,7 @@
 set -euo pipefail
 
 # DO NOT EDIT THE SCRIPT
-# Instead, update the j2 template, and regenerate it for dev:
-# cat <<EOF | jinja2 --format yaml getting_started.sh.j2 -o getting_started.sh
-# helm:
-#   repo_name: stackable-dev
-#   repo_url: https://repo.stackable.tech/repository/helm-dev/
-# versions:
-#   commons: 0.0.0-dev
-#   listener: 0.0.0-dev
-#   secret: 0.0.0-dev
-#   spark: 0.0.0-dev
-# EOF
+# Instead, update the j2 template, and regenerate it for dev with `make render-docs`.
 
 # This script contains all the code snippets from the guide, as well as some assert tests
 # to test if the instructions in the guide work. The user *could* use it, but it is intended


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/611.

Depends on https://github.com/stackabletech/spark-k8s-operator/pull/495.