### PR TITLE
Patch op-rs version to use one that fixes SUP-148.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2172,8 +2172,8 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stackable-operator"
-version = "0.80.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.80.0#6fbe32300b60f95e0baa2ab0ff2daf961b06531c"
+version = "0.81.0"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=fix%2FSUP-148#cd36be73cb4a77ca5c3a8ff6914419af264217c9"
 dependencies = [
  "chrono",
  "clap",
@@ -2211,7 +2211,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator-derive"
 version = "0.3.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.80.0#6fbe32300b60f95e0baa2ab0ff2daf961b06531c"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=fix%2FSUP-148#cd36be73cb4a77ca5c3a8ff6914419af264217c9"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2222,7 +2222,7 @@ dependencies = [
 [[package]]
 name = "stackable-shared"
 version = "0.0.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.80.0#6fbe32300b60f95e0baa2ab0ff2daf961b06531c"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=fix%2FSUP-148#cd36be73cb4a77ca5c3a8ff6914419af264217c9"
 dependencies = [
  "kube",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ tracing = "0.1"
 tracing-futures = { version = "0.2", features = ["futures-03"] }
 indoc = "2"
 
+[patch."https://github.com/stackabletech/operator-rs.git"]
+stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "fix/SUP-148" }
+
 #[patch."https://github.com/stackabletech/operator-rs.git"]
 #stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "main" }
 #stackable-operator = { path = "../operator-rs" }


### PR DESCRIPTION
# Description

Some minor changes needed to remove dependency on now private fn in op-rs.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
