### PR TITLE
fix: Use correct label selector for pod-driver-controller

### DIFF
--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -29,8 +29,8 @@ use stackable_operator::{
 
 use stackable_spark_k8s_crd::{
     constants::{
-        HISTORY_FULL_CONTROLLER_NAME, OPERATOR_NAME, POD_DRIVER_CONTROLLER_NAME,
-        POD_DRIVER_FULL_CONTROLLER_NAME, SPARK_FULL_CONTROLLER_NAME,
+        HISTORY_FULL_CONTROLLER_NAME, OPERATOR_NAME, POD_DRIVER_FULL_CONTROLLER_NAME,
+        SPARK_CONTROLLER_NAME, SPARK_FULL_CONTROLLER_NAME,
     },
     history::SparkHistoryServer,
     SparkApplication,
@@ -146,7 +146,7 @@ async fn main() -> anyhow::Result<()> {
             let pod_driver_controller = Controller::new(
                 watch_namespace.get_api::<DeserializeGuard<Pod>>(&client),
                 watcher::Config::default()
-                    .labels(&format!("app.kubernetes.io/managed-by={OPERATOR_NAME}_{POD_DRIVER_CONTROLLER_NAME},spark-role=driver")),
+                 .labels(&format!("app.kubernetes.io/managed-by={OPERATOR_NAME}_{SPARK_CONTROLLER_NAME},spark-role=driver")),
             )
             .owns(
                 watch_namespace.get_api::<DeserializeGuard<Pod>>(&client),


### PR DESCRIPTION
Fixup of #515

Fixes 

`2025-01-25T14:55:33.797725Z ERROR stackable_operator::logging::controller: Failed to reconcile object controller.name="pod-driver.spark.stackable.tech" error=tried to
 reconcile object Pod.v1./pyspark-pi-20250125145500-5ae7fc949df5a93e-driver.kuttl-test-resolved-flounder that was not found in local store`

# Description

*Please add a description here. This will become the commit message of the merge request later.*

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
