### PR TITLE
test: Update HBase, HDFS and ZooKeeper versions

### DIFF
--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -16,14 +16,14 @@ dimensions:
       # - 3.5.5,oci.stackable.tech/sandbox/spark-k8s:3.5.5-stackable0.0.0-dev
   - name: hbase
     values:
-      - 2.6.0
+      - 2.6.1
       - 2.4.18
   - name: hdfs-latest
     values:
-      - 3.4.0
+      - 3.4.1
   - name: zookeeper-latest
     values:
-      - 3.9.2
+      - 3.9.3
   - name: ny-tlc-report
     values:
       - 0.2.0


### PR DESCRIPTION
Bumps:
- HBase 2.6.1
- HDFS 3.4.1
- ZooKeeper 3.9.3

They seemed to have been missed in https://github.com/stackabletech/docker-images/issues/964.

Companion change: https://github.com/stackabletech/spark-k8s-operator/pull/543