### PR TITLE
ci: Remove Nexus from workflow tasks

### DIFF
--- a/.github/workflows/dev_ny-tlc-report.yaml
+++ b/.github/workflows/dev_ny-tlc-report.yaml
@@ -40,16 +40,6 @@ jobs:
           image-index-manifest-tag: ${{ env.IMAGE_VERSION }}
           container-file: ${{ env.DOCKERFILE_PATH }}
 
-      - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # v0.0.6
-        with:
-          image-registry-uri: docker.stackable.tech
-          image-registry-username: github
-          image-registry-password: ${{ secrets.NEXUS_PASSWORD }}
-          image-repository: stackable/${{ env.IMAGE_NAME }}
-          image-manifest-tag: ${{ steps.build.outputs.image-manifest-tag }}
-          source-image-uri: ${{ steps.build.outputs.image-manifest-uri }}
-
       - name: Publish Container Image on oci.stackable.tech
         uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # v0.0.6
         with:
@@ -69,15 +59,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # v0.0.6
-        with:
-          image-registry-uri: docker.stackable.tech
-          image-registry-username: github
-          image-registry-password: ${{ secrets.NEXUS_PASSWORD }}
-          image-repository: stackable/${{ env.IMAGE_NAME }}
-          image-index-manifest-tag: ${{ env.IMAGE_VERSION }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # v0.0.6


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/infrastructure/issues/142
This PR removes the workflow tasks pushing artifacts to Nexus from a workflow not covered by operator-templating

## Definition of Done Checklist

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
