### PR TITLE
chore: Remove hardcoded uid and gid

### DIFF
--- a/.github/workflows/dev_ny-tlc-report.yaml
+++ b/.github/workflows/dev_ny-tlc-report.yaml
@@ -3,7 +3,7 @@ name: Build and publish ny-tlc-report
 
 env:
   IMAGE_NAME: ny-tlc-report
-  IMAGE_VERSION: 0.2.0
+  IMAGE_VERSION: 0.3.0
   REGISTRY_PATH: stackable
   DOCKERFILE_PATH: "apps/docker/Dockerfile"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ All notable changes to this project will be documented in this file.
 - Use versioned common structs ([#572]).
 - BREAKING: Change the label `app.kubernetes.io/name` for Spark history and connect objects to use `spark-history` and `spark-connect` instead of `spark-k8s` ([#573]).
 - BREAKING: The history Pods now have their own ClusterRole named `spark-history-clusterrole` ([#573]).
+- BREAKING: Previously this operator would hardcode the UID and GID of the Pods being created to 1000/0, this has changed now ([#575])
+  - The `runAsUser` and `runAsGroup` fields will not be set anymore by the operator
+  - The defaults from the docker images itself will now apply, which will be different from 1000/0 going forward
+  - This is marked as breaking because tools and policies might exist, which require these fields to be set
 
 ### Fixed
 
@@ -52,6 +56,7 @@ All notable changes to this project will be documented in this file.
 [#572]: https://github.com/stackabletech/spark-k8s-operator/pull/572
 [#573]: https://github.com/stackabletech/spark-k8s-operator/pull/573
 [#574]: https://github.com/stackabletech/spark-k8s-operator/pull/574
+[#575]: https://github.com/stackabletech/spark-k8s-operator/pull/575
 
 ## [25.3.0] - 2025-03-21
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,5 +1,11 @@
+# Provision Spark applications from seaparate image
 
-# Generate report from the public data set
+## Build the image
+
+    docker build -t oci.stackable.tech/stackable/ny-tlc-report:0.3.0 -f apps/docker/Dockerfile .
+    docker push oci.stackable.tech/stackable/ny-tlc-report:0.3.0
+
+## Generate report from the public data set
 
     spark-submit --conf spark.hadoop.fs.s3a.aws.credentials.provider=org.apache.hadoop.fs.s3a.AnonymousAWSCredentialsProvider --packages org.apache.hadoop:hadoop-aws:3.2.0,com.amazonaws:aws-java-sdk-s3:1.12.180,com.amazonaws:aws-java-sdk-core:1.12.180 ny_tlc_report.py --input 's3a://nyc-tlc/trip data/yellow_tripdata_2021-07.csv'
 

--- a/apps/docker/Dockerfile
+++ b/apps/docker/Dockerfile
@@ -5,4 +5,9 @@ LABEL maintainer="Stackable GmbH"
 
 WORKDIR /jobs
 
+# A user must be specified for the container to run on OpenShift
+# with the nonroot-v2 security context constraint and
+# without a runAsUser container annotation.
+USER 1000
+
 COPY apps/ny_tlc_report.py .

--- a/deploy/helm/spark-k8s-operator/templates/roles.yaml
+++ b/deploy/helm/spark-k8s-operator/templates/roles.yaml
@@ -151,3 +151,13 @@ rules:
       - patch
       - create
       - delete
+{{ if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - nonroot-v2
+    verbs:
+      - use
+{{ end }}

--- a/rust/operator-binary/src/connect/server.rs
+++ b/rust/operator-binary/src/connect/server.rs
@@ -48,7 +48,7 @@ use crate::{
         constants::{
             JVM_SECURITY_PROPERTIES_FILE, LISTENER_VOLUME_DIR, LISTENER_VOLUME_NAME,
             LOG4J2_CONFIG_FILE, MAX_SPARK_LOG_FILES_SIZE, METRICS_PROPERTIES_FILE,
-            POD_TEMPLATE_FILE, SPARK_DEFAULTS_FILE_NAME, SPARK_UID, VOLUME_MOUNT_NAME_CONFIG,
+            POD_TEMPLATE_FILE, SPARK_DEFAULTS_FILE_NAME, VOLUME_MOUNT_NAME_CONFIG,
             VOLUME_MOUNT_NAME_LOG, VOLUME_MOUNT_NAME_LOG_CONFIG, VOLUME_MOUNT_PATH_CONFIG,
             VOLUME_MOUNT_PATH_LOG, VOLUME_MOUNT_PATH_LOG_CONFIG,
         },
@@ -246,8 +246,6 @@ pub(crate) fn build_stateful_set(
         )
         .context(AddVolumeSnafu)?
         .security_context(PodSecurityContext {
-            run_as_user: Some(SPARK_UID),
-            run_as_group: Some(0),
             fs_group: Some(1000),
             ..PodSecurityContext::default()
         });

--- a/rust/operator-binary/src/crd/constants.rs
+++ b/rust/operator-binary/src/crd/constants.rs
@@ -86,7 +86,6 @@ pub const SPARK_DEFAULTS_FILE_NAME: &str = "spark-defaults.conf";
 pub const SPARK_ENV_SH_FILE_NAME: &str = "spark-env.sh";
 
 pub const SPARK_CLUSTER_ROLE: &str = "spark-k8s-clusterrole";
-pub const SPARK_UID: i64 = 1000;
 pub const METRICS_PORT: u16 = 18081;
 pub const HISTORY_UI_PORT: u16 = 18080;
 

--- a/rust/operator-binary/src/history/history_controller.rs
+++ b/rust/operator-binary/src/history/history_controller.rs
@@ -58,7 +58,7 @@ use crate::{
             HISTORY_UI_PORT, JVM_SECURITY_PROPERTIES_FILE, LISTENER_VOLUME_DIR,
             LISTENER_VOLUME_NAME, MAX_SPARK_LOG_FILES_SIZE, METRICS_PORT, OPERATOR_NAME,
             SECRET_ACCESS_KEY, SPARK_DEFAULTS_FILE_NAME, SPARK_ENV_SH_FILE_NAME,
-            SPARK_IMAGE_BASE_NAME, SPARK_UID, STACKABLE_TRUST_STORE, VOLUME_MOUNT_NAME_CONFIG,
+            SPARK_IMAGE_BASE_NAME, STACKABLE_TRUST_STORE, VOLUME_MOUNT_NAME_CONFIG,
             VOLUME_MOUNT_NAME_LOG, VOLUME_MOUNT_NAME_LOG_CONFIG, VOLUME_MOUNT_PATH_CONFIG,
             VOLUME_MOUNT_PATH_LOG, VOLUME_MOUNT_PATH_LOG_CONFIG,
         },
@@ -544,8 +544,6 @@ fn build_stateful_set(
         )
         .context(AddVolumeSnafu)?
         .security_context(PodSecurityContext {
-            run_as_user: Some(SPARK_UID),
-            run_as_group: Some(0),
             fs_group: Some(1000),
             ..PodSecurityContext::default()
         });

--- a/rust/operator-binary/src/spark_k8s_controller.rs
+++ b/rust/operator-binary/src/spark_k8s_controller.rs
@@ -1023,8 +1023,6 @@ fn build_spark_role_serviceaccount(
 
 fn security_context() -> PodSecurityContext {
     PodSecurityContext {
-        run_as_user: Some(SPARK_UID),
-        run_as_group: Some(0),
         fs_group: Some(1000),
         ..PodSecurityContext::default()
     }

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -33,7 +33,7 @@ dimensions:
       - 3.9.3
   - name: ny-tlc-report
     values:
-      - 0.2.0
+      - 0.3.0
   - name: s3-use-tls
     values:
       - "false"


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/issues/issues/651

Remove hardcoded uid and gid, they'll default to the ones from the docker images now.
For 25.7 that means they might change from 1000/0
See https://github.com/stackabletech/docker-images/pull/916 for details

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [x] Integration tests passed (for non trivial changes)

### Reviewer

- [x] Changelog updated

### Acceptance

- [ ] Proper release label has been added
