### PR TITLE
chore: replace jmx exporter with built in Prometheus support

### DIFF
--- a/rust/operator-binary/src/connect/common.rs
+++ b/rust/operator-binary/src/connect/common.rs
@@ -34,6 +34,11 @@ pub enum Error {
     JvmSecurityProperties {
         source: product_config::writer::PropertiesWriterError,
     },
+
+    #[snafu(display("failed to serialize metrics properties",))]
+    MetricsProperties {
+        source: product_config::writer::PropertiesWriterError,
+    },
 }
 
 pub(crate) fn labels<'a, T>(
@@ -149,5 +154,5 @@ pub(crate) fn metrics_properties(
         );
     }
 
-    to_java_properties_string(result.iter()).context(JvmSecurityPropertiesSnafu)
+    to_java_properties_string(result.iter()).context(MetricsPropertiesSnafu)
 }

--- a/rust/operator-binary/src/crd/constants.rs
+++ b/rust/operator-binary/src/crd/constants.rs
@@ -86,7 +86,6 @@ pub const SPARK_DEFAULTS_FILE_NAME: &str = "spark-defaults.conf";
 pub const SPARK_ENV_SH_FILE_NAME: &str = "spark-env.sh";
 
 pub const SPARK_CLUSTER_ROLE: &str = "spark-k8s-clusterrole";
-pub const METRICS_PORT: u16 = 18081;
 pub const HISTORY_UI_PORT: u16 = 18080;
 
 pub const LISTENER_VOLUME_NAME: &str = "listener";

--- a/rust/operator-binary/src/history/config/jvm.rs
+++ b/rust/operator-binary/src/history/config/jvm.rs
@@ -5,9 +5,8 @@ use stackable_operator::role_utils::{
 
 use crate::crd::{
     constants::{
-        JVM_SECURITY_PROPERTIES_FILE, LOG4J2_CONFIG_FILE, METRICS_PORT,
-        STACKABLE_TLS_STORE_PASSWORD, STACKABLE_TRUST_STORE, VOLUME_MOUNT_PATH_CONFIG,
-        VOLUME_MOUNT_PATH_LOG_CONFIG,
+        JVM_SECURITY_PROPERTIES_FILE, LOG4J2_CONFIG_FILE, STACKABLE_TLS_STORE_PASSWORD,
+        STACKABLE_TRUST_STORE, VOLUME_MOUNT_PATH_CONFIG, VOLUME_MOUNT_PATH_LOG_CONFIG,
     },
     history::HistoryConfigFragment,
     logdir::ResolvedLogDir,
@@ -32,9 +31,6 @@ pub fn construct_history_jvm_args(
         format!("-Dlog4j.configurationFile={VOLUME_MOUNT_PATH_LOG_CONFIG}/{LOG4J2_CONFIG_FILE}"),
         format!(
             "-Djava.security.properties={VOLUME_MOUNT_PATH_CONFIG}/{JVM_SECURITY_PROPERTIES_FILE}"
-        ),
-        format!(
-            "-javaagent:/stackable/jmx/jmx_prometheus_javaagent.jar={METRICS_PORT}:/stackable/jmx/config.yaml"
         ),
     ];
 
@@ -86,8 +82,7 @@ mod tests {
         assert_eq!(
             jvm_config,
             "-Dlog4j.configurationFile=/stackable/log_config/log4j2.properties \
-            -Djava.security.properties=/stackable/spark/conf/security.properties \
-            -javaagent:/stackable/jmx/jmx_prometheus_javaagent.jar=18081:/stackable/jmx/config.yaml"
+            -Djava.security.properties=/stackable/spark/conf/security.properties"
         );
     }
 
@@ -130,7 +125,6 @@ mod tests {
             jvm_config,
             "-Dlog4j.configurationFile=/stackable/log_config/log4j2.properties \
             -Djava.security.properties=/stackable/spark/conf/security.properties \
-            -javaagent:/stackable/jmx/jmx_prometheus_javaagent.jar=18081:/stackable/jmx/config.yaml \
             -Dhttps.proxyHost=proxy.my.corp \
             -Djava.net.preferIPv4Stack=true \
             -Dhttps.proxyPort=1234"

--- a/rust/operator-binary/src/history/history_controller.rs
+++ b/rust/operator-binary/src/history/history_controller.rs
@@ -56,11 +56,11 @@ use crate::{
         constants::{
             ACCESS_KEY_ID, HISTORY_APP_NAME, HISTORY_CONTROLLER_NAME, HISTORY_ROLE_NAME,
             HISTORY_UI_PORT, JVM_SECURITY_PROPERTIES_FILE, LISTENER_VOLUME_DIR,
-            LISTENER_VOLUME_NAME, MAX_SPARK_LOG_FILES_SIZE, METRICS_PORT, OPERATOR_NAME,
-            SECRET_ACCESS_KEY, SPARK_DEFAULTS_FILE_NAME, SPARK_ENV_SH_FILE_NAME,
-            SPARK_IMAGE_BASE_NAME, STACKABLE_TRUST_STORE, VOLUME_MOUNT_NAME_CONFIG,
-            VOLUME_MOUNT_NAME_LOG, VOLUME_MOUNT_NAME_LOG_CONFIG, VOLUME_MOUNT_PATH_CONFIG,
-            VOLUME_MOUNT_PATH_LOG, VOLUME_MOUNT_PATH_LOG_CONFIG,
+            LISTENER_VOLUME_NAME, MAX_SPARK_LOG_FILES_SIZE, OPERATOR_NAME, SECRET_ACCESS_KEY,
+            SPARK_DEFAULTS_FILE_NAME, SPARK_ENV_SH_FILE_NAME, SPARK_IMAGE_BASE_NAME,
+            STACKABLE_TRUST_STORE, VOLUME_MOUNT_NAME_CONFIG, VOLUME_MOUNT_NAME_LOG,
+            VOLUME_MOUNT_NAME_LOG_CONFIG, VOLUME_MOUNT_PATH_CONFIG, VOLUME_MOUNT_PATH_LOG,
+            VOLUME_MOUNT_PATH_LOG_CONFIG,
         },
         history::{self, HistoryConfig, SparkHistoryServerContainer, v1alpha1},
         listener_ext,
@@ -574,7 +574,6 @@ fn build_stateful_set(
         ])
         .args(command_args(log_dir))
         .add_container_port("http", HISTORY_UI_PORT.into())
-        .add_container_port("metrics", METRICS_PORT.into())
         .add_env_vars(merged_env)
         .add_volume_mounts(log_dir.volume_mounts())
         .context(AddVolumeMountSnafu)?

--- a/tests/templates/kuttl/spark-connect/30-assert.yaml
+++ b/tests/templates/kuttl/spark-connect/30-assert.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+commands:
+  - script: |
+      # This endpoint (/metrics/prometheus) is also used as liveliness probe
+      echo test Prometheus endpoint for driver metrics
+      DRIVER_METRIC_COUNT=$(kubectl exec spark-connect-server-0 -c spark -n $NAMESPACE -- curl localhost:4040/metrics/prometheus | grep _driver_ | wc -l)
+      test 0 -lt "$DRIVER_METRIC_COUNT"
+
+      echo test Prometheus endpoint for executor metrics
+      EXECUTOR_METRIC_COUNT=$(kubectl exec spark-connect-server-0 -c spark -n $NAMESPACE -- curl localhost:4040/metrics/executors/prometheus | grep _executor_ | wc -l)
+      test 0 -lt "$EXECUTOR_METRIC_COUNT"


### PR DESCRIPTION
## Description

Part of: https://github.com/stackabletech/spark-k8s-operator/issues/582

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
