### PR TITLE
tests: increase spark-connect test timeout

### DIFF
--- a/tests/templates/kuttl/spark-connect/10-assert.yaml
+++ b/tests/templates/kuttl/spark-connect/10-assert.yaml
@@ -33,8 +33,10 @@ commands:
   # while the spark-connect server is busy setting up the executors.
   - script: |
       # wait for the spark-connect CR to become available
-      # this is to prevent the spark apps created in the following test steps to fail intermitently
       kubectl wait --for=condition=Available sparkconnectservers/spark-connect --namespace "$NAMESPACE" --timeout=3m
 
       EXECUTOR_COUNT=$(kubectl get pods -n "$NAMESPACE" --selector 'spark-app-name=spark-connect-server' --field-selector='status.phase=Running' -o NAME|wc -l)
       test 1 -eq "$EXECUTOR_COUNT"
+
+      # wait a little longer to increase the chance apps being able to connect
+      sleep 5

--- a/tests/templates/kuttl/spark-connect/20-assert.yaml
+++ b/tests/templates/kuttl/spark-connect/20-assert.yaml
@@ -3,7 +3,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 metadata:
   name: simple-connect-app
-timeout: 180
+timeout: 300
 ---
 apiVersion: batch/v1
 kind: Job


### PR DESCRIPTION
## Description

Raise assert timout to wait a bit longer for image pulls.

Add a sleep command to increase the chance of apps being able to connect.

Successful on fresh AKS cluster:

```
--- PASS: kuttl (222.68s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/spark-connect_openshift-false_spark-connect-3.5.6_spark-connect-client-3.5.6 (220.11s)
PASS
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
