### PR TITLE
chore: update tests to use bitnamilegacy

### DIFF
--- a/kind/minio.yaml
+++ b/kind/minio.yaml
@@ -29,6 +29,6 @@ spec:
     spec:
       containers:
         - name: minio-mc
-          image: bitnami/minio:2022-debian-10
+          image: bitnamilegacy/minio:2022-debian-10
           stdin: true
           tty: true

--- a/tests/templates/kuttl/delta-lake/20-setup-minio.yaml
+++ b/tests/templates/kuttl/delta-lake/20-setup-minio.yaml
@@ -23,7 +23,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: minio-client
-      image: docker.io/bitnami/minio-client:2024-debian-12
+      image: docker.io/bitnamilegacy/minio-client:2024-debian-12
       command: ["bash", "-c", "sleep infinity"]
       stdin: true
       tty: true

--- a/tests/templates/kuttl/delta-lake/helm-bitnami-minio-values.yaml
+++ b/tests/templates/kuttl/delta-lake/helm-bitnami-minio-values.yaml
@@ -1,6 +1,26 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 14.9.0 if modifying images
+
+image:
+  repository: bitnamilegacy/minio
+clientImage:
+  repository: bitnamilegacy/minio-client
+defaultInitContainers:
+  volumePermissions: # volumePermissions moved under defaultInitContainers starting with Chart version 17.0.0
+    enabled: false
+    image:
+      repository: bitnamilegacy/os-shell
+console:
+  image:
+    repository: bitnamilegacy/minio-object-browser
+
+# volumePermissions can be removed starting with Chart version 17.0.0, moved under defaultInitContainers
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
 
 podSecurityContext:
   enabled: false

--- a/tests/templates/kuttl/logging/02-setup-s3.yaml
+++ b/tests/templates/kuttl/logging/02-setup-s3.yaml
@@ -63,7 +63,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: minio-client
-      image: docker.io/bitnami/minio-client:2023.3.20-debian-11-r1
+      image: docker.io/bitnamilegacy/minio-client:2023.3.20-debian-11-r1
       command: ["bash", "-c", "sleep infinity"]
       stdin: true
       tty: true

--- a/tests/templates/kuttl/logging/helm-bitnami-eventlog-minio-values.yaml
+++ b/tests/templates/kuttl/logging/helm-bitnami-eventlog-minio-values.yaml
@@ -1,6 +1,26 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 14.9.0 if modifying images
+
+image:
+  repository: bitnamilegacy/minio
+clientImage:
+  repository: bitnamilegacy/minio-client
+defaultInitContainers:
+  volumePermissions: # volumePermissions moved under defaultInitContainers starting with Chart version 17.0.0
+    enabled: false
+    image:
+      repository: bitnamilegacy/os-shell
+console:
+  image:
+    repository: bitnamilegacy/minio-object-browser
+
+# volumePermissions can be removed starting with Chart version 17.0.0, moved under defaultInitContainers
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
 
 podSecurityContext:
   enabled: false

--- a/tests/templates/kuttl/overrides/helm-bitnami-eventlog-minio-values.yaml.j2
+++ b/tests/templates/kuttl/overrides/helm-bitnami-eventlog-minio-values.yaml.j2
@@ -1,4 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 14.9.0 if modifying images
+
+image:
+  repository: bitnamilegacy/minio
+clientImage:
+  repository: bitnamilegacy/minio-client
+defaultInitContainers:
+  volumePermissions: # volumePermissions moved under defaultInitContainers starting with Chart version 17.0.0
+    enabled: false
+    image:
+      repository: bitnamilegacy/os-shell
+console:
+  image:
+    repository: bitnamilegacy/minio-object-browser
+
 mode: standalone
 disableWebUI: false
 extraEnvVars:
@@ -25,8 +42,11 @@ provisioning:
   containerSecurityContext:
     enabled: false
 
+# volumePermissions can be removed starting with Chart version 17.0.0, moved under defaultInitContainers
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
 
 podSecurityContext:
   enabled: false

--- a/tests/templates/kuttl/overrides/helm-bitnami-minio-values.yaml
+++ b/tests/templates/kuttl/overrides/helm-bitnami-minio-values.yaml
@@ -1,4 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 14.9.0 if modifying images
+
+image:
+  repository: bitnamilegacy/minio
+clientImage:
+  repository: bitnamilegacy/minio-client
+defaultInitContainers:
+  volumePermissions: # volumePermissions moved under defaultInitContainers starting with Chart version 17.0.0
+    enabled: false
+    image:
+      repository: bitnamilegacy/os-shell
+console:
+  image:
+    repository: bitnamilegacy/minio-object-browser
+
 mode: standalone
 disableWebUI: false
 extraEnvVars:
@@ -25,8 +42,11 @@ provisioning:
   containerSecurityContext:
     enabled: false
 
+# volumePermissions can be removed starting with Chart version 17.0.0, moved under defaultInitContainers
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
 
 podSecurityContext:
   enabled: false

--- a/tests/templates/kuttl/pyspark-ny-public-s3-image/02-setup-minio.yaml
+++ b/tests/templates/kuttl/pyspark-ny-public-s3-image/02-setup-minio.yaml
@@ -23,7 +23,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: minio-client
-      image: docker.io/bitnami/minio-client:2024-debian-12
+      image: docker.io/bitnamilegacy/minio-client:2024-debian-12
       command: ["bash", "-c", "sleep infinity"]
       stdin: true
       tty: true

--- a/tests/templates/kuttl/pyspark-ny-public-s3-image/helm-bitnami-minio-values.yaml
+++ b/tests/templates/kuttl/pyspark-ny-public-s3-image/helm-bitnami-minio-values.yaml
@@ -1,6 +1,26 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 14.9.0 if modifying images
+
+image:
+  repository: bitnamilegacy/minio
+clientImage:
+  repository: bitnamilegacy/minio-client
+defaultInitContainers:
+  volumePermissions: # volumePermissions moved under defaultInitContainers starting with Chart version 17.0.0
+    enabled: false
+    image:
+      repository: bitnamilegacy/os-shell
+console:
+  image:
+    repository: bitnamilegacy/minio-object-browser
+
+# volumePermissions can be removed starting with Chart version 17.0.0, moved under defaultInitContainers
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
 
 podSecurityContext:
   enabled: false

--- a/tests/templates/kuttl/pyspark-ny-public-s3/02-setup-minio.yaml
+++ b/tests/templates/kuttl/pyspark-ny-public-s3/02-setup-minio.yaml
@@ -23,7 +23,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: minio-client
-      image: docker.io/bitnami/minio-client:2024-debian-12
+      image: docker.io/bitnamilegacy/minio-client:2024-debian-12
       command: ["bash", "-c", "sleep infinity"]
       stdin: true
       tty: true

--- a/tests/templates/kuttl/pyspark-ny-public-s3/helm-bitnami-minio-values.yaml
+++ b/tests/templates/kuttl/pyspark-ny-public-s3/helm-bitnami-minio-values.yaml
@@ -1,6 +1,26 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 14.9.0 if modifying images
+
+image:
+  repository: bitnamilegacy/minio
+clientImage:
+  repository: bitnamilegacy/minio-client
+defaultInitContainers:
+  volumePermissions: # volumePermissions moved under defaultInitContainers starting with Chart version 17.0.0
+    enabled: false
+    image:
+      repository: bitnamilegacy/os-shell
+console:
+  image:
+    repository: bitnamilegacy/minio-object-browser
+
+# volumePermissions can be removed starting with Chart version 17.0.0, moved under defaultInitContainers
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
 
 podSecurityContext:
   enabled: false

--- a/tests/templates/kuttl/smoke/helm-bitnami-eventlog-minio-values.yaml.j2
+++ b/tests/templates/kuttl/smoke/helm-bitnami-eventlog-minio-values.yaml.j2
@@ -1,4 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 14.9.0 if modifying images
+
+image:
+  repository: bitnamilegacy/minio
+clientImage:
+  repository: bitnamilegacy/minio-client
+defaultInitContainers:
+  volumePermissions: # volumePermissions moved under defaultInitContainers starting with Chart version 17.0.0
+    enabled: false
+    image:
+      repository: bitnamilegacy/os-shell
+console:
+  image:
+    repository: bitnamilegacy/minio-object-browser
+
 mode: standalone
 disableWebUI: false
 extraEnvVars:
@@ -25,8 +42,11 @@ provisioning:
   containerSecurityContext:
     enabled: false
 
+# volumePermissions can be removed starting with Chart version 17.0.0, moved under defaultInitContainers
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
 
 podSecurityContext:
   enabled: false

--- a/tests/templates/kuttl/smoke/helm-bitnami-minio-values.yaml
+++ b/tests/templates/kuttl/smoke/helm-bitnami-minio-values.yaml
@@ -1,4 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 14.9.0 if modifying images
+
+image:
+  repository: bitnamilegacy/minio
+clientImage:
+  repository: bitnamilegacy/minio-client
+defaultInitContainers:
+  volumePermissions: # volumePermissions moved under defaultInitContainers starting with Chart version 17.0.0
+    enabled: false
+    image:
+      repository: bitnamilegacy/os-shell
+console:
+  image:
+    repository: bitnamilegacy/minio-object-browser
+
 mode: standalone
 disableWebUI: false
 extraEnvVars:
@@ -25,8 +42,11 @@ provisioning:
   containerSecurityContext:
     enabled: false
 
+# volumePermissions can be removed starting with Chart version 17.0.0, moved under defaultInitContainers
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
 
 podSecurityContext:
   enabled: false

--- a/tests/templates/kuttl/spark-connect/helm-bitnami-minio-values.yaml
+++ b/tests/templates/kuttl/spark-connect/helm-bitnami-minio-values.yaml
@@ -1,4 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 14.9.0 if modifying images
+
+image:
+  repository: bitnamilegacy/minio
+clientImage:
+  repository: bitnamilegacy/minio-client
+defaultInitContainers:
+  volumePermissions: # volumePermissions moved under defaultInitContainers starting with Chart version 17.0.0
+    enabled: false
+    image:
+      repository: bitnamilegacy/os-shell
+console:
+  image:
+    repository: bitnamilegacy/minio-object-browser
+
 mode: standalone
 disableWebUI: false
 extraEnvVars:
@@ -25,8 +42,11 @@ provisioning:
   containerSecurityContext:
     enabled: false
 
+# volumePermissions can be removed starting with Chart version 17.0.0, moved under defaultInitContainers
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
 
 podSecurityContext:
   enabled: false

--- a/tests/templates/kuttl/spark-history-server/03-setup-minio.yaml
+++ b/tests/templates/kuttl/spark-history-server/03-setup-minio.yaml
@@ -27,5 +27,5 @@ spec:
   restartPolicy: Never
   containers:
     - name: minio-client
-      image: docker.io/bitnami/minio-client:2023.5.18-debian-11-r2
+      image: docker.io/bitnamilegacy/minio-client:2023.5.18-debian-11-r2
       command: ["bash", "-c", "sleep infinity"]

--- a/tests/templates/kuttl/spark-history-server/helm-bitnami-eventlog-minio-values.yaml.j2
+++ b/tests/templates/kuttl/spark-history-server/helm-bitnami-eventlog-minio-values.yaml.j2
@@ -1,4 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 14.9.0 if modifying images
+
+image:
+  repository: bitnamilegacy/minio
+clientImage:
+  repository: bitnamilegacy/minio-client
+defaultInitContainers:
+  volumePermissions: # volumePermissions moved under defaultInitContainers starting with Chart version 17.0.0
+    enabled: false
+    image:
+      repository: bitnamilegacy/os-shell
+console:
+  image:
+    repository: bitnamilegacy/minio-object-browser
+
 mode: standalone
 disableWebUI: false
 extraEnvVars:
@@ -25,8 +42,11 @@ provisioning:
   containerSecurityContext:
     enabled: false
 
+# volumePermissions can be removed starting with Chart version 17.0.0, moved under defaultInitContainers
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
 
 podSecurityContext:
   enabled: false

--- a/tests/templates/kuttl/spark-history-server/helm-bitnami-minio-values.yaml
+++ b/tests/templates/kuttl/spark-history-server/helm-bitnami-minio-values.yaml
@@ -1,4 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 14.9.0 if modifying images
+
+image:
+  repository: bitnamilegacy/minio
+clientImage:
+  repository: bitnamilegacy/minio-client
+defaultInitContainers:
+  volumePermissions: # volumePermissions moved under defaultInitContainers starting with Chart version 17.0.0
+    enabled: false
+    image:
+      repository: bitnamilegacy/os-shell
+console:
+  image:
+    repository: bitnamilegacy/minio-object-browser
+
 mode: standalone
 disableWebUI: false
 extraEnvVars:
@@ -25,8 +42,11 @@ provisioning:
   containerSecurityContext:
     enabled: false
 
+# volumePermissions can be removed starting with Chart version 17.0.0, moved under defaultInitContainers
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
 
 podSecurityContext:
   enabled: false

--- a/tests/templates/kuttl/spark-ny-public-s3/02-setup-minio.yaml.j2
+++ b/tests/templates/kuttl/spark-ny-public-s3/02-setup-minio.yaml.j2
@@ -23,7 +23,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: minio-client
-      image: docker.io/bitnami/minio-client:2023.5.18-debian-11-r2
+      image: docker.io/bitnamilegacy/minio-client:2023.5.18-debian-11-r2
       command: ["bash", "-c", "sleep infinity"]
 ---
 apiVersion: s3.stackable.tech/v1alpha1

--- a/tests/templates/kuttl/spark-ny-public-s3/helm-bitnami-minio-values.yaml.j2
+++ b/tests/templates/kuttl/spark-ny-public-s3/helm-bitnami-minio-values.yaml.j2
@@ -1,4 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 14.9.0 if modifying images
+
+image:
+  repository: bitnamilegacy/minio
+clientImage:
+  repository: bitnamilegacy/minio-client
+defaultInitContainers:
+  volumePermissions: # volumePermissions moved under defaultInitContainers starting with Chart version 17.0.0
+    enabled: false
+    image:
+      repository: bitnamilegacy/os-shell
+console:
+  image:
+    repository: bitnamilegacy/minio-object-browser
+
 mode: standalone
 disableWebUI: false
 extraEnvVars:
@@ -25,8 +42,11 @@ provisioning:
   containerSecurityContext:
     enabled: false
 
+# volumePermissions can be removed starting with Chart version 17.0.0, moved under defaultInitContainers
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
 
 podSecurityContext:
   enabled: false

--- a/tests/templates/kuttl/spark-pi-private-s3/03-setup-minio.yaml
+++ b/tests/templates/kuttl/spark-pi-private-s3/03-setup-minio.yaml
@@ -23,7 +23,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: minio-client
-      image: docker.io/bitnami/minio-client:2024-debian-12
+      image: docker.io/bitnamilegacy/minio-client:2024-debian-12
       command: ["bash", "-c", "sleep infinity"]
       stdin: true
       tty: true

--- a/tests/templates/kuttl/spark-pi-private-s3/helm-bitnami-minio-values.yaml
+++ b/tests/templates/kuttl/spark-pi-private-s3/helm-bitnami-minio-values.yaml
@@ -1,6 +1,26 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 14.9.0 if modifying images
+
+image:
+  repository: bitnamilegacy/minio
+clientImage:
+  repository: bitnamilegacy/minio-client
+defaultInitContainers:
+  volumePermissions: # volumePermissions moved under defaultInitContainers starting with Chart version 17.0.0
+    enabled: false
+    image:
+      repository: bitnamilegacy/os-shell
+console:
+  image:
+    repository: bitnamilegacy/minio-object-browser
+
+# volumePermissions can be removed starting with Chart version 17.0.0, moved under defaultInitContainers
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
 
 podSecurityContext:
   enabled: false


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/issues/issues/749 Quickfix
This PR updates the tests to use the bitnamilegacy repository for bitnami images. All affected tests ran successfully.

Integrationstests:
```
--- FAIL: kuttl (988.71s)
    --- FAIL: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/spark-pi-private-s3_openshift-false_spark-3.5.6 (177.04s)
        --- FAIL: kuttl/harness/spark-pi-private-s3_openshift-false_spark-3.5.5 (988.69s)
FAIL

--- PASS: kuttl (115.43s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/spark-pi-private-s3_openshift-false_spark-3.5.5 (115.41s)
PASS

--- PASS: kuttl (505.49s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/pyspark-ny-public-s3-image_openshift-false_spark-3.5.5_ny-tlc-report-0.3.0 (131.97s)
        --- PASS: kuttl/harness/spark-ny-public-s3_openshift-false_spark-3.5.5_s3-use-tls-false (133.77s)
        --- PASS: kuttl/harness/spark-ny-public-s3_openshift-false_spark-3.5.6_s3-use-tls-false (123.49s)
        --- PASS: kuttl/harness/spark-ny-public-s3_openshift-false_spark-3.5.6_s3-use-tls-true (131.62s)
        --- PASS: kuttl/harness/spark-ny-public-s3_openshift-false_spark-3.5.5_s3-use-tls-true (126.58s)
        --- PASS: kuttl/harness/pyspark-ny-public-s3_openshift-false_spark-3.5.5 (124.50s)
        --- PASS: kuttl/harness/pyspark-ny-public-s3_openshift-false_spark-3.5.6 (123.12s)
        --- PASS: kuttl/harness/pyspark-ny-public-s3-image_openshift-false_spark-3.5.6_ny-tlc-report-0.3.0 (115.59s)
PASS

--- FAIL: kuttl (1574.18s)
    --- FAIL: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/spark-history-server_openshift-false_spark-3.5.6_s3-use-tls-false (259.81s)
        --- PASS: kuttl/harness/spark-history-server_openshift-false_spark-3.5.5_s3-use-tls-false (259.89s)
        --- PASS: kuttl/harness/spark-history-server_openshift-false_spark-3.5.6_s3-use-tls-true (196.42s)
        --- FAIL: kuttl/harness/spark-history-server_openshift-false_spark-3.5.5_s3-use-tls-true (1314.28s)
FAIL

--- PASS: kuttl (226.82s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/spark-history-server_openshift-false_spark-3.5.5_s3-use-tls-true (226.81s)
PASS

--- PASS: kuttl (185.97s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/spark-connect_openshift-false_spark-connect-3.5.6_spark-connect-client-3.5.6 (185.96s)
PASS

--- PASS: kuttl (308.94s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_openshift-false_spark-3.5.5_s3-use-tls-false (142.91s)
        --- PASS: kuttl/harness/smoke_openshift-false_spark-3.5.6_s3-use-tls-false (153.32s)
        --- PASS: kuttl/harness/smoke_openshift-false_spark-3.5.6_s3-use-tls-true (140.90s)
        --- PASS: kuttl/harness/smoke_openshift-false_spark-3.5.5_s3-use-tls-true (155.60s)
PASS

--- PASS: kuttl (126.00s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/overrides_openshift-false_spark-3.5.6 (125.70s)
        --- PASS: kuttl/harness/overrides_openshift-false_spark-3.5.5 (125.98s)
PASS

--- PASS: kuttl (195.81s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/delta-lake_openshift-false_spark-delta-lake-3.5.6_delta-3.1.0 (195.80s)
PASS

--- PASS: kuttl (332.43s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/logging_openshift-false_spark-3.5.6_ny-tlc-report-0.3.0 (328.18s)
        --- PASS: kuttl/harness/logging_openshift-false_spark-3.5.5_ny-tlc-report-0.3.0 (332.41s)
PASS
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
