### PR TITLE
chore: update example to use bitnamilegacy

### DIFF
--- a/kind/minio.yaml
+++ b/kind/minio.yaml
@@ -29,6 +29,6 @@ spec:
     spec:
       containers:
         - name: minio-mc
-          image: bitnami/minio:2022-debian-10
+          image: bitnamilegacy/minio:2022-debian-10
           stdin: true
           tty: true


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/issues/issues/749 and follow up to https://github.com/stackabletech/spark-k8s-operator/pull/598
This PR updates the example of the 25.7 release to use bitnamilegacy.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
