### PR TITLE
fix: spark connect image pull secrets not passed to executors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- SparkConnectServer: imagePullSecret is not passed to Spark executor pods ([#603]).
+
+[#603]: https://github.com/stackabletech/spark-k8s-operator/pull/603
+
 ## [25.7.0] - 2025-07-23
 
 ## [25.7.0-rc1] - 2025-07-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- SparkConnectServer: imagePullSecret is not passed to Spark executor pods ([#603]).
+- SparkConnectServer: The `imagePullSecret` is now correctly passed to Spark executor pods ([#603]).
 
 [#603]: https://github.com/stackabletech/spark-k8s-operator/pull/603
 

--- a/rust/operator-binary/src/connect/executor.rs
+++ b/rust/operator-binary/src/connect/executor.rs
@@ -132,6 +132,7 @@ pub fn executor_pod_template(
     let mut template = PodBuilder::new();
     template
         .metadata(metadata)
+        .image_pull_secrets_from_product_image(resolved_product_image)
         .affinity(&config.affinity)
         .add_volume(
             VolumeBuilder::new(VOLUME_MOUNT_NAME_LOG)


### PR DESCRIPTION
## Description

Fixes #600

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
