### PR TITLE
chore: Bump zookeeper version for 25.11.0

### DIFF
--- a/tests/templates/kuttl/delta-lake/40-assert.yaml
+++ b/tests/templates/kuttl/delta-lake/40-assert.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 300
+timeout: 500
 ---
 # The Job starting the whole process
 apiVersion: spark.stackable.tech/v1alpha1

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -38,7 +38,7 @@ dimensions:
       - 3.4.1
   - name: zookeeper-latest
     values:
-      - 3.9.3
+      - 3.9.4
   - name: ny-tlc-report
     values:
       - 0.3.0


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/docker-images/issues/1275

### Integrationtests

```
--- FAIL: kuttl (5778.49s)
    --- FAIL: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/pyspark-ny-public-s3-image_openshift-false_spark-4.0.1_ny-tlc-report-0.3.0 (334.32s)
        --- PASS: kuttl/harness/pyspark-ny-public-s3-image_openshift-false_spark-3.5.7_ny-tlc-report-0.3.0 (190.55s)
        --- PASS: kuttl/harness/logging_openshift-false_spark-logging-3.5.7_ny-tlc-report-0.3.0 (717.72s)
        --- PASS: kuttl/harness/pyspark-ny-public-s3-image_openshift-false_spark-3.5.6_ny-tlc-report-0.3.0 (247.91s)
        --- PASS: kuttl/harness/spark-history-server_openshift-false_spark-4.0.1_s3-use-tls-true (317.18s)
        --- PASS: kuttl/harness/spark-history-server_openshift-false_spark-4.0.1_s3-use-tls-false (352.71s)
        --- PASS: kuttl/harness/spark-history-server_openshift-false_spark-3.5.7_s3-use-tls-true (293.70s)
        --- PASS: kuttl/harness/spark-history-server_openshift-false_spark-3.5.7_s3-use-tls-false (297.42s)
        --- PASS: kuttl/harness/spark-history-server_openshift-false_spark-3.5.6_s3-use-tls-true (299.59s)
        --- PASS: kuttl/harness/resources_openshift-false_spark-4.0.1 (170.60s)
        --- PASS: kuttl/harness/resources_openshift-false_spark-3.5.7 (140.06s)
        --- PASS: kuttl/harness/resources_openshift-false_spark-3.5.6 (137.25s)
        --- PASS: kuttl/harness/pyspark-ny-public-s3_openshift-false_spark-4.0.1 (214.91s)
        --- PASS: kuttl/harness/pyspark-ny-public-s3_openshift-false_spark-3.5.7 (179.20s)
        --- FAIL: kuttl/harness/spark-history-server_openshift-false_spark-3.5.6_s3-use-tls-false (1079.35s)
        --- PASS: kuttl/harness/spark-examples_openshift-false_spark-4.0.1 (84.16s)
        --- PASS: kuttl/harness/pyspark-ny-public-s3_openshift-false_spark-3.5.6 (166.21s)
        --- PASS: kuttl/harness/spark-examples_openshift-false_spark-3.5.7 (84.18s)
        --- PASS: kuttl/harness/spark-examples_openshift-false_spark-3.5.6 (67.89s)
        --- PASS: kuttl/harness/spark-ny-public-s3_openshift-false_spark-4.0.1_s3-use-tls-true (215.00s)
        --- PASS: kuttl/harness/spark-ny-public-s3_openshift-false_spark-4.0.1_s3-use-tls-false (205.24s)
        --- PASS: kuttl/harness/spark-ny-public-s3_openshift-false_spark-3.5.7_s3-use-tls-true (185.91s)
        --- PASS: kuttl/harness/spark-ny-public-s3_openshift-false_spark-3.5.7_s3-use-tls-false (182.81s)
        --- PASS: kuttl/harness/spark-ny-public-s3_openshift-false_spark-3.5.6_s3-use-tls-true (180.78s)
        --- PASS: kuttl/harness/spark-ny-public-s3_openshift-false_spark-3.5.6_s3-use-tls-false (168.09s)
        --- PASS: kuttl/harness/smoke_openshift-false_spark-4.0.1_s3-use-tls-false (215.18s)
        --- PASS: kuttl/harness/smoke_openshift-false_spark-4.0.1_s3-use-tls-true (227.39s)
        --- PASS: kuttl/harness/smoke_openshift-false_spark-3.5.7_s3-use-tls-false (183.00s)
        --- PASS: kuttl/harness/smoke_openshift-false_spark-3.5.7_s3-use-tls-true (218.37s)
        --- PASS: kuttl/harness/smoke_openshift-false_spark-3.5.6_s3-use-tls-true (198.86s)
        --- PASS: kuttl/harness/smoke_openshift-false_spark-3.5.6_s3-use-tls-false (172.96s)
        --- PASS: kuttl/harness/spark-pi-private-s3_openshift-false_spark-4.0.1 (152.10s)
        --- PASS: kuttl/harness/spark-pi-private-s3_openshift-false_spark-3.5.7 (141.21s)
        --- FAIL: kuttl/harness/delta-lake_openshift-false_spark-delta-lake-3.5.7_delta-3.1.0 (367.62s)
        --- PASS: kuttl/harness/spark-pi-private-s3_openshift-false_spark-3.5.6 (154.86s)
        --- PASS: kuttl/harness/custom-log-directory_openshift-false_spark-4.0.1_hdfs-latest-3.4.1_zookeeper-latest-3.9.4 (338.69s)
        --- PASS: kuttl/harness/custom-log-directory_openshift-false_spark-3.5.7_hdfs-latest-3.4.1_zookeeper-latest-3.9.4 (272.82s)
        --- PASS: kuttl/harness/custom-log-directory_openshift-false_spark-3.5.6_hdfs-latest-3.4.1_zookeeper-latest-3.9.4 (283.79s)
        --- PASS: kuttl/harness/hbase-connector_openshift-false_spark-hbase-connector-3.5.7_hbase-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.4 (364.03s)
        --- PASS: kuttl/harness/overrides_openshift-false_spark-3.5.7 (184.85s)
        --- PASS: kuttl/harness/overrides_openshift-false_spark-4.0.1 (177.74s)
        --- PASS: kuttl/harness/iceberg_openshift-false_spark-iceberg-3.5.7 (93.46s)
        --- PASS: kuttl/harness/hbase-connector_openshift-false_spark-hbase-connector-3.5.7_hbase-2.6.1_hdfs-latest-3.4.1_zookeeper-latest-3.9.4 (360.16s)
        --- PASS: kuttl/harness/overrides_openshift-false_spark-3.5.6 (217.29s)
        --- PASS: kuttl/harness/spark-connect_openshift-false_spark-connect-4.0.1 (262.06s)
        --- PASS: kuttl/harness/spark-connect_openshift-false_spark-connect-3.5.7 (249.05s)
FAIL

--- PASS: kuttl (273.64s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/spark-history-server_openshift-false_spark-3.5.6_s3-use-tls-false (273.63s)
PASS

--- PASS: kuttl (403.71s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/delta-lake_openshift-false_spark-delta-lake-3.5.7_delta-3.1.0 (403.69s)
PASS
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
