### PR TITLE
docs: Fix callout

### DIFF
--- a/docs/modules/spark-k8s/examples/getting_started/application.yaml
+++ b/docs/modules/spark-k8s/examples/getting_started/application.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   sparkImage: # <2>
     productVersion: 3.5.7
-  mode: cluster # <4>
+  mode: cluster # <3>
   mainApplicationFile: local:///stackable/spark/examples/src/main/python/pi.py # <4>
   job: # <5>
     config:


### PR DESCRIPTION
Small fixup of https://github.com/stackabletech/spark-k8s-operator/pull/623 that prevents documentation to build