### PR TITLE
fix: remove application owner reference from the executor pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,18 @@ All notable changes to this project will be documented in this file.
   See [objectOverrides concepts page](https://docs.stackable.tech/home/nightly/concepts/overrides/#object-overrides) for details ([#640]).
 - Support for Spark `4.1.1` ([#642]).
 
+### Changed
+
+- Remove the Spark application owner reference from the executor pods.
+  This allows Kubernetes to garbage collect them early when the driver or the submit job fail ([#648]).
+
 ### Removed
 
 - Support for Spark `3.5.6` ([#642]).
 
 [#640]: https://github.com/stackabletech/spark-k8s-operator/pull/640
 [#642]: https://github.com/stackabletech/spark-k8s-operator/pull/642
+[#648]: https://github.com/stackabletech/spark-k8s-operator/pull/648
 
 ## [25.11.0] - 2025-11-07
 


### PR DESCRIPTION
## Description

:yellow_circle: CI https://testing.stackable.tech/view/02%20Operator%20Tests%20(custom)/job/spark-k8s-operator-it-custom/54/

2 failing tests not related with this pr.
