### PR TITLE
test: Bump ZooKeeper version to 3.9.5 in integration tests

### DIFF
--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -55,7 +55,7 @@ dimensions:
       - 3.4.2
   - name: zookeeper-latest
     values:
-      - 3.9.4
+      - 3.9.5
   - name: ny-tlc-report
     values:
       - 0.3.0


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1506.