### PR TITLE
chore: Bump Rust edition to 2024

### DIFF
--- a/Cargo.nix
+++ b/Cargo.nix
@@ -9865,7 +9865,7 @@ rec {
       "stackable-spark-k8s-operator" = rec {
         crateName = "stackable-spark-k8s-operator";
         version = "0.0.0-dev";
-        edition = "2021";
+        edition = "2024";
         crateBin = [
           {
             name = "stackable-spark-k8s-operator";

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 version = "0.0.0-dev"
 authors = ["Stackable GmbH <info@stackable.tech>"]
 license = "OSL-3.0"
-edition = "2021"
+edition = "2024"
 repository = "https://github.com/stackabletech/spark-k8s-operator"
 
 [workspace.dependencies]

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -407,10 +407,10 @@ impl v1alpha1::SparkApplication {
             );
         }
 
-        if let Some(log_dir) = logdir.as_ref() {
-            if let Some(volume) = log_dir.credentials_volume().context(ConfigureLogDirSnafu)? {
-                result.insert(volume.name.clone(), volume);
-            }
+        if let Some(log_dir) = logdir.as_ref()
+            && let Some(volume) = log_dir.credentials_volume().context(ConfigureLogDirSnafu)?
+        {
+            result.insert(volume.name.clone(), volume);
         }
 
         if let Some(log_config_map) = log_config_map {

--- a/rust/operator-binary/src/crd/template_merger.rs
+++ b/rust/operator-binary/src/crd/template_merger.rs
@@ -157,12 +157,11 @@ fn merge_pod_template_spec(base: &PodTemplateSpec, overlay: &PodTemplateSpec) ->
         base.spec.as_ref(),
         overlay.spec.as_ref(),
         merged.spec.as_mut(),
-    ) {
-        if let Some(overlay_node_selector) = overlay_spec.node_selector.as_ref() {
-            let mut node_selector = base_spec.node_selector.clone().unwrap_or_default();
-            node_selector.extend(overlay_node_selector.clone());
-            merged_spec.node_selector = Some(node_selector);
-        }
+    ) && let Some(overlay_node_selector) = overlay_spec.node_selector.as_ref()
+    {
+        let mut node_selector = base_spec.node_selector.clone().unwrap_or_default();
+        node_selector.extend(overlay_node_selector.clone());
+        merged_spec.node_selector = Some(node_selector);
     }
 
     merged

--- a/rust/operator-binary/src/crd/tlscerts.rs
+++ b/rust/operator-binary/src/crd/tlscerts.rs
@@ -20,7 +20,7 @@ pub fn tls_secret_name(s3conn: &s3::v1alpha1::ConnectionSpec) -> Option<&str> {
                     Some(Tls {
                         verification:
                             TlsVerification::Server(TlsServerVerification {
-                                ca_cert: CaCert::SecretClass(ref secret_name),
+                                ca_cert: CaCert::SecretClass(secret_name),
                             }),
                     }),
             },
@@ -44,10 +44,10 @@ pub fn tls_secret_names<'a>(
         names.insert(secret_name);
     }
 
-    if let Some(logdir) = logdir {
-        if let Some(secret_name) = logdir.tls_secret_name() {
-            names.insert(secret_name);
-        }
+    if let Some(logdir) = logdir
+        && let Some(secret_name) = logdir.tls_secret_name()
+    {
+        names.insert(secret_name);
     }
     if names.is_empty() {
         None

--- a/rust/operator-binary/src/history/controller.rs
+++ b/rust/operator-binary/src/history/controller.rs
@@ -765,17 +765,17 @@ fn cleaner_config(
     }
 
     // check if cleaner is set for this rolegroup ref
-    if cleaner_rolegroups.len() == 1 && cleaner_rolegroups[0].role_group == rolegroup_ref.role_group
+    if cleaner_rolegroups.len() == 1
+        && cleaner_rolegroups[0].role_group == rolegroup_ref.role_group
+        && let Some(replicas) = shs.replicas(rolegroup_ref)
     {
-        if let Some(replicas) = shs.replicas(rolegroup_ref) {
-            if replicas > 1 {
-                return TooManyCleanerReplicasSnafu.fail();
-            } else {
-                result.insert(
-                    "spark.history.fs.cleaner.enabled".to_string(),
-                    "true".to_string(),
-                );
-            }
+        if replicas > 1 {
+            return TooManyCleanerReplicasSnafu.fail();
+        } else {
+            result.insert(
+                "spark.history.fs.cleaner.enabled".to_string(),
+                "true".to_string(),
+            );
         }
     }
 

--- a/rust/operator-binary/src/spark_k8s_controller/validate.rs
+++ b/rust/operator-binary/src/spark_k8s_controller/validate.rs
@@ -85,13 +85,13 @@ pub fn validate(
 }
 
 fn reject_tls_no_verification(conn: &s3::v1alpha1::ConnectionSpec, context: &str) -> Result<()> {
-    if let Some(tls) = &conn.tls.tls {
-        if matches!(&tls.verification, TlsVerification::None {}) {
-            return S3TlsNoVerificationNotSupportedSnafu {
-                context: context.to_owned(),
-            }
-            .fail();
+    if let Some(tls) = &conn.tls.tls
+        && matches!(&tls.verification, TlsVerification::None {})
+    {
+        return S3TlsNoVerificationNotSupportedSnafu {
+            context: context.to_owned(),
         }
+        .fail();
     }
     Ok(())
 }

--- a/rust/operator-binary/src/webhooks/conversion.rs
+++ b/rust/operator-binary/src/webhooks/conversion.rs
@@ -63,7 +63,7 @@ pub async fn create_webhook_server(
         field_manager: FIELD_MANAGER.to_owned(),
     };
 
-    let (conversion_webhook, _initial_reconcile_rx) =
+    let (conversion_webhook, _) =
         ConversionWebhook::new(crds_and_handlers, client, conversion_webhook_options);
 
     let webhook_server_options = WebhookServerOptions {


### PR DESCRIPTION
Run `cargo fix --edition` and resolve resulting warnings:

- Add `use<>` syntax to `impl Trait` return types (auto-fixed)
- Fix Rust 2024 temporary drop order change by simplifying `_initial_reconcile_rx` handling
- Apply Clippy suggestions
  - Use `&& let` chaining instead of nested `if let`
Part of https://github.com/stackabletech/issues/issues/832
## Description

*Please add a description here. This will become the commit message of the merge request later.*

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
