### PR TITLE
fix: make application templates namespaced

### DIFF
--- a/docs/modules/spark-k8s/pages/usage-guide/app_templates.adoc
+++ b/docs/modules/spark-k8s/pages/usage-guide/app_templates.adoc
@@ -5,13 +5,23 @@ Spark application templates are used to define reusable configurations for Spark
 When you have many applications with similar configurations, templates can help you avoid duplication by grouping common settings together.
 Application templates are available for the `v1alpha1` version of the SparkApplication custom resource and share the exact same structure as the SparkApplication resource, but with some differences in the way the operator handles them:
 
-1. Application templates are cluster wide resources, while Spark application resources are namespace-scoped.
-  This means that application templates can be used across multiple namespaces, while Spark application resources are limited to the namespace they are created in.
+1. Application templates are namespace-scoped resources, just like Spark applications.
+  This means that a SparkApplication can only reference templates from its own namespace.
 2. Application templates are not reconciled by the operator, but must be referenced from a SparkApplication resource to be applied. This means that changes to an application template will not automatically trigger updates to SparkApplication resources that reference it.
 3. An application can reference multiple application templates, and the settings from these templates will be merged together. The merging order of the templates is indicated by their index in the reference list. The application fields have the highest precedence and will override any conflicting settings from the templates. This allows you to have a base template with common settings and then override specific settings in the application resource as needed.
 4. Application template references are immutable in the sense that once applied to an application they cannot be changed again. Currently templates are applied upon the creation of the application, and any changes to the template references after that will be ignored.
 5. Application and template CRDs must have the exact same versions. Currently only `v1alpha1` is supported.
 
+== Migrating from cluster-scoped templates
+
+IMPORTANT: Application templates used to be cluster wide resources when they were first released. This was a mistake. Many users do not have the access rights to create cluster scoped resources and so the templates are now namespace scoped.
+
+If you are migrating from older installations where templates were treated as cluster-wide resources, account for the following:
+
+1. Recreate each template in every namespace where SparkApplications use it.
+2. Keep template names consistent per namespace if you want the same application annotations to continue working.
+3. Cross-namespace template references are no longer resolved; templates and applications must be in the same namespace.
+4. Update GitOps/automation manifests to create templates as namespace-targeted resources before reconciling dependent SparkApplications.
 == Examples
 
 Applications use `metadata.annotations` to reference application templates as shown below:

--- a/extra/crds.yaml
+++ b/extra/crds.yaml
@@ -4639,7 +4639,7 @@ spec:
     shortNames:
     - sparkapptemplate
     singular: sparkapplicationtemplate
-  scope: Cluster
+  scope: Namespaced
   versions:
   - additionalPrinterColumns: []
     name: v1alpha1

--- a/rust/operator-binary/src/crd/template_merger.rs
+++ b/rust/operator-binary/src/crd/template_merger.rs
@@ -313,6 +313,47 @@ mod tests {
     }
 
     #[test]
+    fn test_deep_merge_metadata_namespace_overlay_wins() {
+        let base = serde_yaml::from_str::<crate::crd::v1alpha1::SparkApplication>(indoc! {r#"
+            ---
+            apiVersion: spark.stackable.tech/v1alpha1
+            kind: SparkApplication
+            metadata:
+              name: base-app
+              namespace: template-namespace
+            spec:
+              mode: cluster
+              mainApplicationFile: base.py
+              sparkImage:
+                productVersion: "3.5.0"
+        "#})
+        .unwrap();
+
+        let overlay = serde_yaml::from_str::<crate::crd::v1alpha1::SparkApplication>(indoc! {r#"
+            ---
+            apiVersion: spark.stackable.tech/v1alpha1
+            kind: SparkApplication
+            metadata:
+              name: overlay-app
+              namespace: app-namespace
+            spec:
+              mode: cluster
+              mainApplicationFile: overlay.py
+              sparkImage:
+                productVersion: "3.5.1"
+        "#})
+        .unwrap();
+
+        let merged = deep_merge(&base, &overlay);
+
+        assert_eq!(
+            merged.metadata.namespace,
+            Some("app-namespace".to_string()),
+            "overlay namespace should take precedence"
+        );
+    }
+
+    #[test]
     fn test_deep_merge_spark_conf() {
         let base = serde_yaml::from_str::<crate::crd::v1alpha1::SparkApplication>(indoc! {r#"
             ---

--- a/rust/operator-binary/src/crd/template_spec.rs
+++ b/rust/operator-binary/src/crd/template_spec.rs
@@ -44,6 +44,9 @@ pub enum Error {
         template_name: String,
         source: stackable_operator::kube::Error,
     },
+
+    #[snafu(display("object has no namespace"))]
+    ObjectHasNoNamespace,
 }
 
 #[versioned(
@@ -65,6 +68,7 @@ pub mod versioned {
         group = "spark.stackable.tech",
         plural = "sparkapptemplates",
         shortname = "sparkapptemplate",
+        namespaced
     ))]
     #[derive(Clone, CustomResource, Debug, Deserialize, JsonSchema, Serialize)]
     #[serde(rename_all = "camelCase")]
@@ -262,8 +266,10 @@ pub(crate) async fn merge_application_templates(
         // In the future if we support additional strategies in addition to "enforce",
         // this list might not be identical to the one in `merge_template_options`
         // because some objects might be missing.
+        let namespace = spark_application_namespace(spark_application)?;
         let templates = resolve(
             client,
+            namespace,
             &merge_template_options.template_names,
             merge_template_options.apply_strategy,
         )
@@ -316,8 +322,19 @@ pub(crate) async fn merge_application_templates(
     Ok(default_result)
 }
 
+fn spark_application_namespace(
+    spark_application: &super::v1alpha1::SparkApplication,
+) -> Result<&str, Error> {
+    spark_application
+        .metadata
+        .namespace
+        .as_deref()
+        .ok_or(Error::ObjectHasNoNamespace)
+}
+
 async fn resolve(
     client: &stackable_operator::client::Client,
+    namespace: &str,
     template_names: &[String],
     apply_strategy: TemplateApplyStrategy,
 ) -> Result<Vec<v1alpha1::SparkApplicationTemplate>, Error> {
@@ -325,7 +342,8 @@ async fn resolve(
         return Ok(vec![]);
     }
 
-    let templates_api = Api::<v1alpha1::SparkApplicationTemplate>::all(client.as_kube_client());
+    let templates_api =
+        Api::<v1alpha1::SparkApplicationTemplate>::namespaced(client.as_kube_client(), namespace);
     let mut resolved_templates = Vec::new();
     for template_name in template_names {
         let template_res = templates_api
@@ -431,6 +449,53 @@ mod tests {
             TemplateApplyStrategy::Enforce
         ));
         assert!(options.template_names.is_empty());
+    }
+
+    #[test]
+    fn spark_application_namespace_returns_namespace() {
+        let spark_application =
+            serde_yaml::from_str::<crate::crd::v1alpha1::SparkApplication>(indoc! {r#"
+                ---
+                apiVersion: spark.stackable.tech/v1alpha1
+                kind: SparkApplication
+                metadata:
+                  name: app-with-templates
+                  namespace: default
+                spec:
+                  mode: cluster
+                  mainApplicationFile: local:///app.py
+                  sparkImage:
+                    productVersion: "3.5.8"
+            "#})
+            .unwrap();
+
+        assert_eq!(
+            spark_application_namespace(&spark_application).unwrap(),
+            "default"
+        );
+    }
+
+    #[test]
+    fn spark_application_namespace_returns_error_when_missing() {
+        let spark_application =
+            serde_yaml::from_str::<crate::crd::v1alpha1::SparkApplication>(indoc! {r#"
+                ---
+                apiVersion: spark.stackable.tech/v1alpha1
+                kind: SparkApplication
+                metadata:
+                  name: app-with-templates
+                spec:
+                  mode: cluster
+                  mainApplicationFile: local:///app.py
+                  sparkImage:
+                    productVersion: "3.5.8"
+            "#})
+            .unwrap();
+
+        assert!(matches!(
+            spark_application_namespace(&spark_application),
+            Err(Error::ObjectHasNoNamespace)
+        ));
     }
 
     impl RoundtripTestData for v1alpha1::SparkApplicationTemplateSpec {


### PR DESCRIPTION
## Description

__Update__: [it was decided](https://app.nuclino.com/Stackable/Engineering/Cluster-wide-vs-namespaced-objects-ac9f9597-1781-4d8f-b41a-ed82b02ef0c2) that application templates should be namespaced.
~~DO NOT MERGE until the proposal in the linked issue is decided upon.~~

Fixes #693

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)