### PR TITLE
chore: Remove support for 3.5.7 and 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ All notable changes to this project will be documented in this file.
 
 ### Removed
 
+- Support for Spark `3.5.7` and `4.0.1` ([#695])
 - Support for Spark `3.5.6` ([#642]).
 - Deprecated support for Spark `3.5.7` ([#650]).
 
@@ -84,6 +85,7 @@ All notable changes to this project will be documented in this file.
 [#663]: https://github.com/stackabletech/spark-k8s-operator/pull/663
 [#664]: https://github.com/stackabletech/spark-k8s-operator/pull/664
 [#666]: https://github.com/stackabletech/spark-k8s-operator/pull/666
+[#695]: https://github.com/stackabletech/spark-k8s-operator/pull/695
 
 ## [25.11.0] - 2025-11-07
 

--- a/docs/modules/spark-k8s/examples/example-history-app.yaml
+++ b/docs/modules/spark-k8s/examples/example-history-app.yaml
@@ -5,7 +5,7 @@ metadata:
   name: spark-pi-s3-1
 spec:
   sparkImage:
-    productVersion: 3.5.8
+    productVersion: 4.1.1
     pullPolicy: IfNotPresent
   mode: cluster
   mainClass: org.apache.spark.examples.SparkPi

--- a/docs/modules/spark-k8s/examples/example-history-server.yaml
+++ b/docs/modules/spark-k8s/examples/example-history-server.yaml
@@ -5,7 +5,7 @@ metadata:
   name: spark-history
 spec:
   image:
-    productVersion: 3.5.8
+    productVersion: 4.1.1
   logFileDirectory: # <1>
     s3:
       prefix: eventlogs/ # <2>

--- a/docs/modules/spark-k8s/examples/example-sparkapp-configmap.yaml
+++ b/docs/modules/spark-k8s/examples/example-sparkapp-configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
 spec:
   sparkImage:
-    productVersion: 3.5.8
+    productVersion: 4.1.1
   mode: cluster
   mainApplicationFile: s3a://stackable-spark-k8s-jars/jobs/ny-tlc-report-1.1.0.jar # <3>
   mainClass: tech.stackable.demo.spark.NYTLCReport

--- a/docs/modules/spark-k8s/examples/example-sparkapp-image.yaml
+++ b/docs/modules/spark-k8s/examples/example-sparkapp-image.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   image: oci.stackable.tech/stackable/ny-tlc-report:0.2.0 # <1>
   sparkImage:
-    productVersion: 3.5.8
+    productVersion: 4.1.1
   mode: cluster
   mainApplicationFile: local:///stackable/spark/jobs/ny_tlc_report.py # <2>
   args:

--- a/docs/modules/spark-k8s/examples/example-sparkapp-pvc.yaml
+++ b/docs/modules/spark-k8s/examples/example-sparkapp-pvc.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
 spec:
   sparkImage:
-    productVersion: 3.5.8
+    productVersion: 4.1.1
   mode: cluster
   mainApplicationFile: s3a://my-bucket/app.jar # <1>
   mainClass: org.example.App # <2>

--- a/docs/modules/spark-k8s/examples/example-sparkapp-s3-private.yaml
+++ b/docs/modules/spark-k8s/examples/example-sparkapp-s3-private.yaml
@@ -5,7 +5,7 @@ metadata:
   name: example-sparkapp-s3-private
 spec:
   sparkImage:
-    productVersion: 3.5.8
+    productVersion: 4.1.1
   mode: cluster
   mainApplicationFile: s3a://my-bucket/spark-examples.jar # <1>
   mainClass: org.apache.spark.examples.SparkPi # <2>

--- a/docs/modules/spark-k8s/examples/example-sparkapp-streaming.yaml
+++ b/docs/modules/spark-k8s/examples/example-sparkapp-streaming.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
 spec:
   sparkImage:
-    productVersion: 3.5.8
+    productVersion: 4.1.1
   mode: cluster
   mainApplicationFile: local:///stackable/spark/examples/src/main/python/streaming/hdfs_wordcount.py
   args:

--- a/docs/modules/spark-k8s/examples/getting_started/application.yaml
+++ b/docs/modules/spark-k8s/examples/getting_started/application.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
 spec:
   sparkImage: # <2>
-    productVersion: 3.5.8
+    productVersion: 4.1.1
   mode: cluster # <3>
   mainApplicationFile: local:///stackable/spark/examples/src/main/python/pi.py # <4>
   job: # <5>

--- a/docs/modules/spark-k8s/partials/supported-versions.adoc
+++ b/docs/modules/spark-k8s/partials/supported-versions.adoc
@@ -6,8 +6,6 @@
 - 4.1.1 (Hadoop 3.4.2, Scala 2.13, Python 3.12, Java 21) (LTS)
 - 3.5.8 (Hadoop 3.4.2, Scala 2.12, Python 3.11, Java 17) (Deprecated)
 
-Apache Spark 4.1.1 has the following known issues (as of February 2026):
+Apache Spark 4.1.1 has the following known issues (as of July 2026):
 
-- Missing HBase compatibility (See: https://github.com/apache/hbase-connectors/pull/130)
-- No Iceberg Spark runtime release with support for Spark 4.1 available yet.
-- No Delta Lake release with support for Spark 4.1 available yet.
+- Missing HBase compatibility (See: https://issues.apache.org/jira/browse/HBASE-30178)

--- a/docs/modules/spark-k8s/partials/supported-versions.adoc
+++ b/docs/modules/spark-k8s/partials/supported-versions.adoc
@@ -3,10 +3,8 @@
 // Stackable Platform documentation.
 // Please sort the versions in descending order (newest first)
 
-- 4.1.1 (Hadoop 3.4.2, Scala 2.13, Python 3.12, Java 21)
-- 4.0.1 (Hadoop 3.4.2, Scala 2.13, Python 3.12, Java 21) (Deprecated)
-- 3.5.8 (Hadoop 3.4.2, Scala 2.12, Python 3.11, Java 17) (LTS)
-- 3.5.7 (Hadoop 3.4.2, Scala 2.12, Python 3.11, Java 17) (Deprecated)
+- 4.1.1 (Hadoop 3.4.2, Scala 2.13, Python 3.12, Java 21) (LTS)
+- 3.5.8 (Hadoop 3.4.2, Scala 2.12, Python 3.11, Java 17) (Deprecated)
 
 Apache Spark 4.1.1 has the following known issues (as of February 2026):
 

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -5,46 +5,35 @@ dimensions:
       - "false"
   - name: spark
     values:
-      - 3.5.7
       - 3.5.8
-      - 4.0.1
       - 4.1.1
       # Alternatively, if you want to use a custom image, append a comma and the full image name to the product version
       # as in the example below.
       # - 3.5.6,oci.stackable.tech/sandbox/spark-k8s:3.5.6-stackable0.0.0-dev
   - name: spark-logging
     values:
-      - 3.5.7
       - 3.5.8
-      - 4.0.1
       - 4.1.1
   - name: spark-hbase-connector
     values:
-      - 3.5.7
       - 3.5.8
       # No hbase-connector release with support for Spark 4 yet.
       # - 4.0.1
       # - 4.1.1
   - name: spark-delta-lake
     values:
-      - 3.5.7
       - 3.5.8
-      - 4.0.1
       # No delta-lake release with support for Spark 4.1 yet
       # - 4.1.1
       # - 3.5.6,oci.stackable.tech/sandbox/spark-k8s:3.5.6-stackable0.0.0-dev
   - name: spark-iceberg
     values:
-      - 3.5.7
       - 3.5.8
-      - 4.0.1
       # No iceberg release with support for Spark 4.1 yet
       # - 4.1.1
   - name: spark-connect
     values:
-      - 3.5.7
       - 3.5.8
-      - 4.0.1
       - 4.1.1
       # - 3.5.6,oci.stackable.tech/sandbox/spark-k8s:3.5.6-stackable0.0.0-dev
   - name: hbase


### PR DESCRIPTION
## Description

Removing spark versions 3.5.7 and 4.0.1, deprecate 3.5.8 and LTS 4.1.1.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Links to generated (nightly) docs added
- [x] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
