### PR TITLE
Revert "fix: make application templates namespaced (#694)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ All notable changes to this project will be documented in this file.
 - Internal operator refactoring: introduce dereference() and validate() steps in the reconciler for spark application, spark connect and spark history server([#687]).
 - test: Bump vector-aggregator to 0.55.0, replace /graphql call with gRPC call ([#689]).
 - Fix the `SparkApplication` CRD description, which incorrectly described it as a "Spark cluster stacklet" rather than a Spark application ([#705]).
-- BREAKING: make application templates namespaced instead of cluster wide objects ([#694]).
 
 [#674]: https://github.com/stackabletech/spark-k8s-operator/pull/674
 [#679]: https://github.com/stackabletech/spark-k8s-operator/pull/679
@@ -39,7 +38,6 @@ All notable changes to this project will be documented in this file.
 [#687]: https://github.com/stackabletech/spark-k8s-operator/pull/687
 [#689]: https://github.com/stackabletech/spark-k8s-operator/pull/689
 [#692]: https://github.com/stackabletech/spark-k8s-operator/pull/692
-[#694]: https://github.com/stackabletech/spark-k8s-operator/pull/694
 [#696]: https://github.com/stackabletech/spark-k8s-operator/pull/696
 [#705]: https://github.com/stackabletech/spark-k8s-operator/pull/705
 [#708]: https://github.com/stackabletech/spark-k8s-operator/pull/708

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -5109,7 +5109,7 @@ rec {
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
           rev = "013bbf43f7006a4ddfc08a147f68441ed88b462b";
-          sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
+          sha256 = "1ab5qmawljwbll6b44gw3md57s9kjiy5p16akz6rv52j6fdxjpgr";
         };
         libName = "k8s_version";
         authors = [
@@ -9893,7 +9893,7 @@ rec {
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
           rev = "013bbf43f7006a4ddfc08a147f68441ed88b462b";
-          sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
+          sha256 = "1ab5qmawljwbll6b44gw3md57s9kjiy5p16akz6rv52j6fdxjpgr";
         };
         libName = "stackable_certs";
         authors = [
@@ -9996,7 +9996,7 @@ rec {
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
           rev = "013bbf43f7006a4ddfc08a147f68441ed88b462b";
-          sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
+          sha256 = "1ab5qmawljwbll6b44gw3md57s9kjiy5p16akz6rv52j6fdxjpgr";
         };
         libName = "stackable_operator";
         authors = [
@@ -10195,7 +10195,7 @@ rec {
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
           rev = "013bbf43f7006a4ddfc08a147f68441ed88b462b";
-          sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
+          sha256 = "1ab5qmawljwbll6b44gw3md57s9kjiy5p16akz6rv52j6fdxjpgr";
         };
         procMacro = true;
         libName = "stackable_operator_derive";
@@ -10230,7 +10230,7 @@ rec {
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
           rev = "013bbf43f7006a4ddfc08a147f68441ed88b462b";
-          sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
+          sha256 = "1ab5qmawljwbll6b44gw3md57s9kjiy5p16akz6rv52j6fdxjpgr";
         };
         libName = "stackable_shared";
         authors = [
@@ -10417,7 +10417,7 @@ rec {
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
           rev = "013bbf43f7006a4ddfc08a147f68441ed88b462b";
-          sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
+          sha256 = "1ab5qmawljwbll6b44gw3md57s9kjiy5p16akz6rv52j6fdxjpgr";
         };
         libName = "stackable_telemetry";
         authors = [
@@ -10527,7 +10527,7 @@ rec {
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
           rev = "013bbf43f7006a4ddfc08a147f68441ed88b462b";
-          sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
+          sha256 = "1ab5qmawljwbll6b44gw3md57s9kjiy5p16akz6rv52j6fdxjpgr";
         };
         libName = "stackable_versioned";
         authors = [
@@ -10577,7 +10577,7 @@ rec {
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
           rev = "013bbf43f7006a4ddfc08a147f68441ed88b462b";
-          sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
+          sha256 = "1ab5qmawljwbll6b44gw3md57s9kjiy5p16akz6rv52j6fdxjpgr";
         };
         procMacro = true;
         libName = "stackable_versioned_macros";
@@ -10645,7 +10645,7 @@ rec {
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
           rev = "013bbf43f7006a4ddfc08a147f68441ed88b462b";
-          sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
+          sha256 = "1ab5qmawljwbll6b44gw3md57s9kjiy5p16akz6rv52j6fdxjpgr";
         };
         libName = "stackable_webhook";
         authors = [

--- a/crate-hashes.json
+++ b/crate-hashes.json
@@ -1,12 +1,12 @@
 {
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#k8s-version@0.1.3": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#stackable-certs@0.4.1": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#stackable-operator-derive@0.3.1": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#stackable-operator@0.113.3": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#stackable-shared@0.1.2": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#stackable-telemetry@0.6.5": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#stackable-versioned-macros@0.11.1": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#stackable-versioned@0.11.1": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#stackable-webhook@0.9.2": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#k8s-version@0.1.3": "1ab5qmawljwbll6b44gw3md57s9kjiy5p16akz6rv52j6fdxjpgr",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#stackable-certs@0.4.1": "1ab5qmawljwbll6b44gw3md57s9kjiy5p16akz6rv52j6fdxjpgr",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#stackable-operator-derive@0.3.1": "1ab5qmawljwbll6b44gw3md57s9kjiy5p16akz6rv52j6fdxjpgr",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#stackable-operator@0.113.3": "1ab5qmawljwbll6b44gw3md57s9kjiy5p16akz6rv52j6fdxjpgr",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#stackable-shared@0.1.2": "1ab5qmawljwbll6b44gw3md57s9kjiy5p16akz6rv52j6fdxjpgr",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#stackable-telemetry@0.6.5": "1ab5qmawljwbll6b44gw3md57s9kjiy5p16akz6rv52j6fdxjpgr",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#stackable-versioned-macros@0.11.1": "1ab5qmawljwbll6b44gw3md57s9kjiy5p16akz6rv52j6fdxjpgr",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#stackable-versioned@0.11.1": "1ab5qmawljwbll6b44gw3md57s9kjiy5p16akz6rv52j6fdxjpgr",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#stackable-webhook@0.9.2": "1ab5qmawljwbll6b44gw3md57s9kjiy5p16akz6rv52j6fdxjpgr",
   "git+https://github.com/stackabletech/product-config.git?tag=0.8.0#product-config@0.8.0": "1dz70kapm2wdqcr7ndyjji0lhsl98bsq95gnb2lw487wf6yr7987"
 }

--- a/docs/modules/spark-k8s/pages/usage-guide/app_templates.adoc
+++ b/docs/modules/spark-k8s/pages/usage-guide/app_templates.adoc
@@ -5,23 +5,13 @@ Spark application templates are used to define reusable configurations for Spark
 When you have many applications with similar configurations, templates can help you avoid duplication by grouping common settings together.
 Application templates are available for the `v1alpha1` version of the SparkApplication custom resource and share the exact same structure as the SparkApplication resource, but with some differences in the way the operator handles them:
 
-1. Application templates are namespace-scoped resources, just like Spark applications.
-  This means that a SparkApplication can only reference templates from its own namespace.
+1. Application templates are cluster wide resources, while Spark application resources are namespace-scoped.
+  This means that application templates can be used across multiple namespaces, while Spark application resources are limited to the namespace they are created in.
 2. Application templates are not reconciled by the operator, but must be referenced from a SparkApplication resource to be applied. This means that changes to an application template will not automatically trigger updates to SparkApplication resources that reference it.
 3. An application can reference multiple application templates, and the settings from these templates will be merged together. The merging order of the templates is indicated by their index in the reference list. The application fields have the highest precedence and will override any conflicting settings from the templates. This allows you to have a base template with common settings and then override specific settings in the application resource as needed.
 4. Application template references are immutable in the sense that once applied to an application they cannot be changed again. Currently templates are applied upon the creation of the application, and any changes to the template references after that will be ignored.
 5. Application and template CRDs must have the exact same versions. Currently only `v1alpha1` is supported.
 
-== Migrating from cluster-scoped templates
-
-IMPORTANT: Application templates used to be cluster wide resources when they were first released. This was a mistake. Many users do not have the access rights to create cluster scoped resources and so the templates are now namespace scoped.
-
-If you are migrating from older installations where templates were treated as cluster-wide resources, account for the following:
-
-1. Recreate each template in every namespace where SparkApplications use it.
-2. Keep template names consistent per namespace if you want the same application annotations to continue working.
-3. Cross-namespace template references are no longer resolved; templates and applications must be in the same namespace.
-4. Update GitOps/automation manifests to create templates as namespace-targeted resources before reconciling dependent SparkApplications.
 == Examples
 
 Applications use `metadata.annotations` to reference application templates as shown below:

--- a/extra/crds.yaml
+++ b/extra/crds.yaml
@@ -4621,7 +4621,7 @@ spec:
     shortNames:
     - sparkapptemplate
     singular: sparkapplicationtemplate
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns: []
     name: v1alpha1

--- a/rust/operator-binary/src/crd/template_merger.rs
+++ b/rust/operator-binary/src/crd/template_merger.rs
@@ -318,47 +318,6 @@ mod tests {
     }
 
     #[test]
-    fn test_deep_merge_metadata_namespace_overlay_wins() {
-        let base = serde_yaml::from_str::<crate::crd::v1alpha1::SparkApplication>(indoc! {r#"
-            ---
-            apiVersion: spark.stackable.tech/v1alpha1
-            kind: SparkApplication
-            metadata:
-              name: base-app
-              namespace: template-namespace
-            spec:
-              mode: cluster
-              mainApplicationFile: base.py
-              sparkImage:
-                productVersion: "3.5.0"
-        "#})
-        .unwrap();
-
-        let overlay = serde_yaml::from_str::<crate::crd::v1alpha1::SparkApplication>(indoc! {r#"
-            ---
-            apiVersion: spark.stackable.tech/v1alpha1
-            kind: SparkApplication
-            metadata:
-              name: overlay-app
-              namespace: app-namespace
-            spec:
-              mode: cluster
-              mainApplicationFile: overlay.py
-              sparkImage:
-                productVersion: "3.5.1"
-        "#})
-        .unwrap();
-
-        let merged = deep_merge(&base, &overlay);
-
-        assert_eq!(
-            merged.metadata.namespace,
-            Some("app-namespace".to_string()),
-            "overlay namespace should take precedence"
-        );
-    }
-
-    #[test]
     fn test_deep_merge_spark_conf() {
         let base = serde_yaml::from_str::<crate::crd::v1alpha1::SparkApplication>(indoc! {r#"
             ---

--- a/rust/operator-binary/src/crd/template_spec.rs
+++ b/rust/operator-binary/src/crd/template_spec.rs
@@ -44,9 +44,6 @@ pub enum Error {
         template_name: String,
         source: stackable_operator::kube::Error,
     },
-
-    #[snafu(display("object has no namespace"))]
-    ObjectHasNoNamespace,
 }
 
 #[versioned(
@@ -69,7 +66,6 @@ pub mod versioned {
         group = "spark.stackable.tech",
         plural = "sparkapptemplates",
         shortname = "sparkapptemplate",
-        namespaced
     ))]
     #[derive(Clone, CustomResource, Debug, Deserialize, JsonSchema, Serialize)]
     #[serde(rename_all = "camelCase")]
@@ -267,10 +263,8 @@ pub(crate) async fn merge_application_templates(
         // In the future if we support additional strategies in addition to "enforce",
         // this list might not be identical to the one in `merge_template_options`
         // because some objects might be missing.
-        let namespace = spark_application_namespace(spark_application)?;
         let templates = resolve(
             client,
-            namespace,
             &merge_template_options.template_names,
             merge_template_options.apply_strategy,
         )
@@ -323,19 +317,8 @@ pub(crate) async fn merge_application_templates(
     Ok(default_result)
 }
 
-fn spark_application_namespace(
-    spark_application: &super::v1alpha1::SparkApplication,
-) -> Result<&str, Error> {
-    spark_application
-        .metadata
-        .namespace
-        .as_deref()
-        .ok_or(Error::ObjectHasNoNamespace)
-}
-
 async fn resolve(
     client: &stackable_operator::client::Client,
-    namespace: &str,
     template_names: &[String],
     apply_strategy: TemplateApplyStrategy,
 ) -> Result<Vec<v1alpha1::SparkApplicationTemplate>, Error> {
@@ -343,8 +326,7 @@ async fn resolve(
         return Ok(vec![]);
     }
 
-    let templates_api =
-        Api::<v1alpha1::SparkApplicationTemplate>::namespaced(client.as_kube_client(), namespace);
+    let templates_api = Api::<v1alpha1::SparkApplicationTemplate>::all(client.as_kube_client());
     let mut resolved_templates = Vec::new();
     for template_name in template_names {
         let template_res = templates_api
@@ -450,53 +432,6 @@ mod tests {
             TemplateApplyStrategy::Enforce
         ));
         assert!(options.template_names.is_empty());
-    }
-
-    #[test]
-    fn spark_application_namespace_returns_namespace() {
-        let spark_application =
-            serde_yaml::from_str::<crate::crd::v1alpha1::SparkApplication>(indoc! {r#"
-                ---
-                apiVersion: spark.stackable.tech/v1alpha1
-                kind: SparkApplication
-                metadata:
-                  name: app-with-templates
-                  namespace: default
-                spec:
-                  mode: cluster
-                  mainApplicationFile: local:///app.py
-                  sparkImage:
-                    productVersion: "3.5.8"
-            "#})
-            .unwrap();
-
-        assert_eq!(
-            spark_application_namespace(&spark_application).unwrap(),
-            "default"
-        );
-    }
-
-    #[test]
-    fn spark_application_namespace_returns_error_when_missing() {
-        let spark_application =
-            serde_yaml::from_str::<crate::crd::v1alpha1::SparkApplication>(indoc! {r#"
-                ---
-                apiVersion: spark.stackable.tech/v1alpha1
-                kind: SparkApplication
-                metadata:
-                  name: app-with-templates
-                spec:
-                  mode: cluster
-                  mainApplicationFile: local:///app.py
-                  sparkImage:
-                    productVersion: "3.5.8"
-            "#})
-            .unwrap();
-
-        assert!(matches!(
-            spark_application_namespace(&spark_application),
-            Err(Error::ObjectHasNoNamespace)
-        ));
     }
 
     impl RoundtripTestData for v1alpha1::SparkApplicationTemplateSpec {


### PR DESCRIPTION
This reverts commit b326be35a5e3c4168b1eea4931b5994f2c7d0e0d (pr #694) because it breaks operator upgrades.

Any remedy (workaround) involves manual intervention and/or possibly  downtime.

The error when running `stackablectl release upgrade dev`::

```text
Error: failed to run webhook server

Caused by:
    0: failed to update certificate
    1: conversion webhook error
    2: failed to patch CRD "sparkapptemplates.spark.stackable.tech"
    3: ApiError: [CustomResourceDefinition.apiextensions.k8s.io](http://customresourcedefinition.apiextensions.k8s.io/) "sparkapptemplates.spark.stackable.tech" is invalid: spec.scope: Invalid value: "Namespaced": field is immutable: Invalid (Status { status: Some(Failure), code: 422, message: "[CustomResourceDefinition.apiextensions.k8s.io](http://customresourcedefinition.apiextensions.k8s.io/) \"sparkapptemplates.spark.stackable.tech\" is invalid: spec.scope: Invalid value: \"Namespaced\": field is immutable", metadata: Some(ListMeta { continue_: None, remaining_item_count: None, resource_version: None, self_link: None, shard_info: None }), reason: "Invalid", details: Some(StatusDetails { name: "sparkapptemplates.spark.stackable.tech", group: "[apiextensions.k8s.io](http://apiextensions.k8s.io/)", kind: "CustomResourceDefinition", uid: "", causes: [StatusCause { reason: "FieldValueInvalid", message: "Invalid value: \"Namespaced\": field is immutable", field: "spec.scope" }], retry_after_seconds: 0 }) })
    4: [CustomResourceDefinition.apiextensions.k8s.io](http://customresourcedefinition.apiextensions.k8s.io/) "sparkapptemplates.spark.stackable.tech" is invalid: spec.scope: Invalid value: "Namespaced": field is immutable: Invalid
stream closed: EOF for stackable-operators/spark-k8s-operator-deployment-575544b9c4-rr487 (spark-k8s-operator)
```

:heavy_check_mark: Tested locally. This test (spark-history...) uses app templates:

```
--- PASS: kuttl (155.61s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/spark-history-server_openshift-false_spark-3.5.8_s3-use-tls-false (150.56s)
        --- PASS: kuttl/harness/spark-history-server_openshift-false_spark-3.5.8_s3-use-tls-true (155.59s)
PASS
```

## Description

*Please add a description here. This will become the commit message of the merge request later.*

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
