### PR TITLE
fix: Use operator name in docs templating script

### DIFF
--- a/scripts/docs_templating.sh
+++ b/scripts/docs_templating.sh
@@ -39,6 +39,8 @@ do
 done
 
 # Ensure this script is executable
-chmod +x docs/modules/opensearch/examples/getting_started/getting_started.sh
+chmod +x "docs/modules/spark-k8s/examples/getting_started/getting_started.sh" \
+  || chmod +x "docs/modules/spark-k8s/examples/getting_started/code/getting_started.sh" \
+  || true
 
 echo "done"


### PR DESCRIPTION
Cherry-pick of #722