### PR TITLE
refactor: Build RBAC with recommended labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ All notable changes to this project will be documented in this file.
   server reconcilers that assembles all relevant Kubernetes resources before anything
   is applied ([#721]).
 - Bump stackable-operator to 0.114.0 ([#732]).
+- The RBAC ServiceAccounts and RoleBindings of the history and connect servers are now
+  built with the operator-rs `v2::rbac` functions and carry the recommended labels ([#727]).
 
 [#721]: https://github.com/stackabletech/spark-k8s-operator/pull/721
+[#727]: https://github.com/stackabletech/spark-k8s-operator/pull/727
 [#732]: https://github.com/stackabletech/spark-k8s-operator/pull/732
 
 ## [26.7.0] - 2026-07-21

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,5 @@ indoc = "2"
 regex = "1.12"
 
 [patch."https://github.com/stackabletech/operator-rs.git"]
-# stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch="main" }
+stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch="feat/smooth-operator/build-rbac" }
 # stackable-operator = { path = "../operator-rs/crates/stackable-operator" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,5 @@ indoc = "2"
 regex = "1.12"
 
 [patch."https://github.com/stackabletech/operator-rs.git"]
-stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch="feat/smooth-operator/build-rbac" }
+# stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch="feat/smooth-operator/build-rbac" }
 # stackable-operator = { path = "../operator-rs/crates/stackable-operator" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,5 @@ indoc = "2"
 regex = "1.12"
 
 [patch."https://github.com/stackabletech/operator-rs.git"]
-# stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch="feat/smooth-operator/build-rbac" }
+# stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch="main" }
 # stackable-operator = { path = "../operator-rs/crates/stackable-operator" }

--- a/rust/operator-binary/src/connect/common.rs
+++ b/rust/operator-binary/src/connect/common.rs
@@ -1,11 +1,12 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, str::FromStr};
 
 use snafu::{ResultExt, Snafu};
 use stackable_operator::v2::{
     config_file_writer::{PropertiesWriterError, to_java_properties_string},
     role_utils::JavaCommonConfig,
+    types::operator::RoleName,
 };
-use strum::Display;
+use strum::{Display, EnumIter};
 
 use super::crd::CONNECT_EXECUTOR_ROLE_NAME;
 use crate::{
@@ -29,11 +30,28 @@ pub enum Error {
     MetricsProperties { source: PropertiesWriterError },
 }
 
-#[derive(Clone, Debug, Display)]
+#[derive(Clone, Debug, Display, EnumIter)]
 #[strum(serialize_all = "lowercase")]
 pub(crate) enum SparkConnectRole {
     Server,
     Executor,
+}
+
+impl From<SparkConnectRole> for RoleName {
+    fn from(value: SparkConnectRole) -> Self {
+        (&value).into()
+    }
+}
+
+impl From<&SparkConnectRole> for RoleName {
+    fn from(value: &SparkConnectRole) -> Self {
+        match value {
+            SparkConnectRole::Server => RoleName::from_str(CONNECT_SERVER_ROLE_NAME)
+                .expect("CONNECT_SERVER_ROLE_NAME is a valid role name"),
+            SparkConnectRole::Executor => RoleName::from_str(CONNECT_EXECUTOR_ROLE_NAME)
+                .expect("CONNECT_EXECUTOR_ROLE_NAME is a valid role name"),
+        }
+    }
 }
 
 pub(crate) fn object_name(stacklet_name: &str, role: SparkConnectRole) -> String {
@@ -109,4 +127,22 @@ pub(crate) fn metrics_properties(
     result.extend(config_overrides);
 
     to_java_properties_string(result.iter()).context(MetricsPropertiesSnafu)
+}
+
+#[cfg(test)]
+mod tests {
+    use stackable_operator::v2::types::operator::RoleName;
+    use strum::IntoEnumIterator;
+
+    use super::SparkConnectRole;
+
+    /// Locks the invariant behind the `expect` in the `From<SparkConnectRole> for RoleName`
+    /// impls: every variant (present and future) must map to a valid `RoleName`.
+    #[test]
+    fn every_spark_connect_role_maps_to_a_valid_role_name() {
+        for role in SparkConnectRole::iter() {
+            let _: RoleName = (&role).into();
+            let _: RoleName = role.into();
+        }
+    }
 }

--- a/rust/operator-binary/src/connect/controller.rs
+++ b/rust/operator-binary/src/connect/controller.rs
@@ -65,11 +65,6 @@ pub enum Error {
         source: error_boundary::InvalidObject,
     },
 
-    #[snafu(display("failed to build RBAC resources"))]
-    BuildRbacResources {
-        source: stackable_operator::commons::rbac::Error,
-    },
-
     #[snafu(display("failed to dereference SparkConnectServer"))]
     DereferenceSparkConnectServer { source: dereference::Error },
 

--- a/rust/operator-binary/src/connect/controller.rs
+++ b/rust/operator-binary/src/connect/controller.rs
@@ -54,12 +54,6 @@ pub enum Error {
         source: stackable_operator::cluster_resources::Error,
     },
 
-    #[snafu(display("failed to get required Labels"))]
-    GetRequiredLabels {
-        source:
-            stackable_operator::kvp::KeyValuePairError<stackable_operator::kvp::LabelValueError>,
-    },
-
     #[snafu(display("SparkConnectServer object is invalid"))]
     InvalidSparkConnectServer {
         source: error_boundary::InvalidObject,

--- a/rust/operator-binary/src/connect/controller.rs
+++ b/rust/operator-binary/src/connect/controller.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use snafu::{ResultExt, Snafu};
 use stackable_operator::{
     cluster_resources::ClusterResourceApplyStrategy,
-    commons::rbac::build_rbac_resources,
     crd::listener,
     k8s_openapi::api::{
         apps::v1::StatefulSet,
@@ -25,7 +24,7 @@ use stackable_operator::{
 };
 use strum::{EnumDiscriminants, IntoStaticStr};
 
-use super::crd::{CONNECT_APP_NAME, v1alpha1};
+use super::crd::v1alpha1;
 use crate::{Ctx, connect::crd::SparkConnectServerStatus, crd::constants::OPERATOR_NAME};
 
 pub mod build;
@@ -41,16 +40,6 @@ pub enum Error {
 
     #[snafu(display("failed to apply Kubernetes resource"))]
     ApplyResource {
-        source: stackable_operator::cluster_resources::Error,
-    },
-
-    #[snafu(display("failed to apply role ServiceAccount"))]
-    ApplyServiceAccount {
-        source: stackable_operator::cluster_resources::Error,
-    },
-
-    #[snafu(display("failed to apply global RoleBinding"))]
-    ApplyRoleBinding {
         source: stackable_operator::cluster_resources::Error,
     },
 
@@ -150,20 +139,7 @@ pub async fn reconcile(
         &scs.spec.object_overrides,
     );
 
-    // Use a dedicated service account for connect server pods. Building the RBAC resources needs
-    // the cluster-resource labels, so it stays in the reconcile step; the built objects (whose
-    // names are deterministic) are handed to the client-free build step.
-    let (service_account, role_binding) = build_rbac_resources(
-        scs,
-        CONNECT_APP_NAME,
-        cluster_resources
-            .get_required_labels()
-            .context(GetRequiredLabelsSnafu)?,
-    )
-    .context(BuildRbacResourcesSnafu)?;
-
-    let resources = build::build(&validated, service_account, role_binding, &scs.spec.args)
-        .context(BuildResourcesSnafu)?;
+    let resources = build::build(&validated, &scs.spec.args).context(BuildResourcesSnafu)?;
 
     // Apply order: ServiceAccount and RoleBinding first, then the Services, ConfigMaps and
     // Listener, and finally the StatefulSet (it mounts the ConfigMaps and runs under the SA, so
@@ -171,11 +147,11 @@ pub async fn reconcile(
     cluster_resources
         .add(client, resources.service_account)
         .await
-        .context(ApplyServiceAccountSnafu)?;
+        .context(ApplyResourceSnafu)?;
     cluster_resources
         .add(client, resources.role_binding)
         .await
-        .context(ApplyRoleBindingSnafu)?;
+        .context(ApplyResourceSnafu)?;
     for service in resources.services {
         cluster_resources
             .add(client, service)

--- a/rust/operator-binary/src/connect/controller/build/executor.rs
+++ b/rust/operator-binary/src/connect/controller/build/executor.rs
@@ -30,7 +30,7 @@ use stackable_operator::{
 use crate::{
     connect::{
         common::{self, SparkConnectRole, object_name},
-        controller::validate::ValidatedSparkConnectServer,
+        controller::{build::object_meta, validate::ValidatedSparkConnectServer},
         crd::{
             CONNECT_EXECUTOR_ROLE_NAME, DEFAULT_SPARK_CONNECT_GROUP_NAME, SparkConnectContainer,
             v1alpha1,
@@ -351,11 +351,7 @@ pub(crate) fn executor_config_map(
     let mut cm_builder = ConfigMapBuilder::new();
 
     cm_builder
-        .metadata(
-            validated
-                .object_meta(&cm_name, SparkConnectRole::Executor)
-                .build(),
-        )
+        .metadata(object_meta(validated, &cm_name, SparkConnectRole::Executor).build())
         .add_data(JVM_SECURITY_PROPERTIES_FILE, jvm_sec_props)
         .add_data(METRICS_PROPERTIES_FILE, metrics_props);
 

--- a/rust/operator-binary/src/connect/controller/build/mod.rs
+++ b/rust/operator-binary/src/connect/controller/build/mod.rs
@@ -109,3 +109,98 @@ pub(crate) fn build(
         stateful_set,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use indoc::indoc;
+    use stackable_operator::{cli::OperatorEnvironmentOptions, utils::yaml_from_str_singleton_map};
+
+    use super::build;
+    use crate::connect::{
+        controller::{
+            dereference::DereferencedSparkConnectServer,
+            validate::{ValidatedSparkConnectServer, validate},
+        },
+        crd::v1alpha1,
+        s3::ResolvedS3,
+    };
+
+    /// Minimal S3-free `SparkConnectServer` fixture, keeping the dereference step client-free;
+    /// the `uid` allows owner references to be derived from it.
+    const CONNECT_YAML: &str = indoc! {r#"
+        apiVersion: spark.stackable.tech/v1alpha1
+        kind: SparkConnectServer
+        metadata:
+          name: my-connect
+          namespace: default
+          uid: 12345678-1234-1234-1234-123456789012
+        spec:
+          image:
+            productVersion: 4.1.2
+        "#};
+
+    /// Runs the real validate step against the minimal fixture.
+    fn minimal_validated_cluster() -> ValidatedSparkConnectServer {
+        let scs: v1alpha1::SparkConnectServer = yaml_from_str_singleton_map(CONNECT_YAML)
+            .expect("invalid test SparkConnectServer YAML");
+        validate(
+            &scs,
+            DereferencedSparkConnectServer {
+                resolved_s3: ResolvedS3::none(),
+            },
+            &OperatorEnvironmentOptions {
+                operator_namespace: "stackable-operators".to_string(),
+                operator_service_name: "spark-k8s-operator".to_string(),
+                image_repository: "oci.example.org/sdp".to_string(),
+            },
+        )
+        .expect("validate should succeed for the test fixture")
+    }
+
+    /// Locks the RBAC resource names, the roleRef, and the recommended label set against
+    /// accidental drift. The fixture's cluster name deliberately differs from the product name so
+    /// that swapped `name`/`instance` label values cannot pass unnoticed.
+    #[test]
+    fn build_produces_rbac() {
+        let resources = build(&minimal_validated_cluster(), &[]).expect("build succeeds");
+
+        assert_eq!(
+            resources.service_account.metadata.name.as_deref(),
+            Some("my-connect-serviceaccount")
+        );
+        assert_eq!(
+            resources.role_binding.metadata.name.as_deref(),
+            Some("my-connect-rolebinding")
+        );
+
+        let expected_labels = BTreeMap::from(
+            [
+                ("app.kubernetes.io/component", "none"),
+                ("app.kubernetes.io/instance", "my-connect"),
+                (
+                    "app.kubernetes.io/managed-by",
+                    "spark.stackable.tech_connect",
+                ),
+                ("app.kubernetes.io/name", "spark-connect"),
+                ("app.kubernetes.io/role-group", "none"),
+                ("app.kubernetes.io/version", "4.1.2-stackable0.0.0-dev"),
+                ("stackable.tech/vendor", "Stackable"),
+            ]
+            .map(|(key, value)| (key.to_string(), value.to_string())),
+        );
+        assert_eq!(
+            resources.service_account.metadata.labels,
+            Some(expected_labels.clone())
+        );
+        assert_eq!(
+            resources.role_binding.metadata.labels,
+            Some(expected_labels)
+        );
+        assert_eq!(
+            resources.role_binding.role_ref.name,
+            "spark-connect-clusterrole"
+        );
+    }
+}

--- a/rust/operator-binary/src/connect/controller/build/mod.rs
+++ b/rust/operator-binary/src/connect/controller/build/mod.rs
@@ -6,18 +6,20 @@
 //! together in one module is clearer than scattering them across per-kind modules.
 
 pub(crate) mod executor;
+pub(crate) mod rbac;
 pub(crate) mod server;
 pub(crate) mod service;
 
 use snafu::{ResultExt, Snafu};
-use stackable_operator::{
-    k8s_openapi::api::{core::v1::ServiceAccount, rbac::v1::RoleBinding},
-    kube::ResourceExt,
-};
+use stackable_operator::kube::ResourceExt;
 
 use crate::connect::{
     common,
-    controller::{SparkConnectResources, validate::ValidatedSparkConnectServer},
+    controller::{
+        SparkConnectResources,
+        build::rbac::{build_role_binding, build_service_account},
+        validate::ValidatedSparkConnectServer,
+    },
 };
 
 #[derive(Snafu, Debug)]
@@ -56,8 +58,6 @@ pub enum Error {
 /// Builds every Kubernetes resource for the given validated SparkConnectServer.
 pub(crate) fn build(
     validated: &ValidatedSparkConnectServer,
-    service_account: ServiceAccount,
-    role_binding: RoleBinding,
     user_args: &[String],
 ) -> Result<SparkConnectResources, Error> {
     let resolved_s3 = &validated.cluster_config.resolved_s3;
@@ -70,8 +70,7 @@ pub(crate) fn build(
         resolved_s3
             .spark_properties()
             .context(S3SparkPropertiesSnafu)?,
-        server::server_properties(validated, &headless_service, &service_account)
-            .context(ServerPropertiesSnafu)?,
+        server::server_properties(validated, &headless_service).context(ServerPropertiesSnafu)?,
         executor::executor_properties(validated).context(ExecutorPropertiesSnafu)?,
     ])
     .context(SerializePropertiesSnafu)?;
@@ -97,18 +96,13 @@ pub(crate) fn build(
     let listener = server::build_listener(validated);
 
     let args = server::command_args(user_args);
-    let stateful_set = server::build_stateful_set(
-        validated,
-        &service_account,
-        &server_config_map,
-        &listener.name_any(),
-        args,
-    )
-    .context(BuildServerStatefulSetSnafu)?;
+    let stateful_set =
+        server::build_stateful_set(validated, &server_config_map, &listener.name_any(), args)
+            .context(BuildServerStatefulSetSnafu)?;
 
     Ok(SparkConnectResources {
-        service_account,
-        role_binding,
+        service_account: build_service_account(validated),
+        role_binding: build_role_binding(validated),
         services: vec![headless_service, metrics_service],
         config_maps: vec![executor_config_map, server_config_map],
         listener,

--- a/rust/operator-binary/src/connect/controller/build/mod.rs
+++ b/rust/operator-binary/src/connect/controller/build/mod.rs
@@ -111,13 +111,10 @@ pub(crate) fn build(
 }
 
 #[cfg(test)]
-mod tests {
-    use std::collections::BTreeMap;
-
+pub(crate) mod test_support {
     use indoc::indoc;
     use stackable_operator::{cli::OperatorEnvironmentOptions, utils::yaml_from_str_singleton_map};
 
-    use super::build;
     use crate::connect::{
         controller::{
             dereference::DereferencedSparkConnectServer,
@@ -129,7 +126,11 @@ mod tests {
 
     /// Minimal S3-free `SparkConnectServer` fixture, keeping the dereference step client-free;
     /// the `uid` allows owner references to be derived from it.
-    const CONNECT_YAML: &str = indoc! {r#"
+    ///
+    /// The cluster name (`my-connect`) deliberately differs from the product name
+    /// (`spark-connect`), so tests asserting recommended labels catch swapped `name`/`instance`
+    /// values.
+    pub const CONNECT_YAML: &str = indoc! {r#"
         apiVersion: spark.stackable.tech/v1alpha1
         kind: SparkConnectServer
         metadata:
@@ -142,7 +143,7 @@ mod tests {
         "#};
 
     /// Runs the real validate step against the minimal fixture.
-    fn minimal_validated_cluster() -> ValidatedSparkConnectServer {
+    pub fn minimal_validated_cluster() -> ValidatedSparkConnectServer {
         let scs: v1alpha1::SparkConnectServer = yaml_from_str_singleton_map(CONNECT_YAML)
             .expect("invalid test SparkConnectServer YAML");
         validate(
@@ -157,50 +158,5 @@ mod tests {
             },
         )
         .expect("validate should succeed for the test fixture")
-    }
-
-    /// Locks the RBAC resource names, the roleRef, and the recommended label set against
-    /// accidental drift. The fixture's cluster name deliberately differs from the product name so
-    /// that swapped `name`/`instance` label values cannot pass unnoticed.
-    #[test]
-    fn build_produces_rbac() {
-        let resources = build(&minimal_validated_cluster(), &[]).expect("build succeeds");
-
-        assert_eq!(
-            resources.service_account.metadata.name.as_deref(),
-            Some("my-connect-serviceaccount")
-        );
-        assert_eq!(
-            resources.role_binding.metadata.name.as_deref(),
-            Some("my-connect-rolebinding")
-        );
-
-        let expected_labels = BTreeMap::from(
-            [
-                ("app.kubernetes.io/component", "none"),
-                ("app.kubernetes.io/instance", "my-connect"),
-                (
-                    "app.kubernetes.io/managed-by",
-                    "spark.stackable.tech_connect",
-                ),
-                ("app.kubernetes.io/name", "spark-connect"),
-                ("app.kubernetes.io/role-group", "none"),
-                ("app.kubernetes.io/version", "4.1.2-stackable0.0.0-dev"),
-                ("stackable.tech/vendor", "Stackable"),
-            ]
-            .map(|(key, value)| (key.to_string(), value.to_string())),
-        );
-        assert_eq!(
-            resources.service_account.metadata.labels,
-            Some(expected_labels.clone())
-        );
-        assert_eq!(
-            resources.role_binding.metadata.labels,
-            Some(expected_labels)
-        );
-        assert_eq!(
-            resources.role_binding.role_ref.name,
-            "spark-connect-clusterrole"
-        );
     }
 }

--- a/rust/operator-binary/src/connect/controller/build/mod.rs
+++ b/rust/operator-binary/src/connect/controller/build/mod.rs
@@ -11,10 +11,13 @@ pub(crate) mod server;
 pub(crate) mod service;
 
 use snafu::{ResultExt, Snafu};
-use stackable_operator::kube::ResourceExt;
+use stackable_operator::{
+    builder::meta::ObjectMetaBuilder, kube::ResourceExt,
+    v2::builder::meta::ownerreference_from_resource,
+};
 
 use crate::connect::{
-    common,
+    common::{self, SparkConnectRole},
     controller::{
         SparkConnectResources,
         build::rbac::{build_role_binding, build_service_account},
@@ -108,6 +111,22 @@ pub(crate) fn build(
         listener,
         stateful_set,
     })
+}
+
+/// Object metadata for a child resource named `name`, owned by the SparkConnectServer and
+/// carrying the recommended labels for the given role.
+pub(crate) fn object_meta(
+    validated: &ValidatedSparkConnectServer,
+    name: impl Into<String>,
+    role: SparkConnectRole,
+) -> ObjectMetaBuilder {
+    let mut builder = ObjectMetaBuilder::new();
+    builder
+        .name_and_namespace(validated)
+        .name(name)
+        .ownerreference(ownerreference_from_resource(validated, None, Some(true)))
+        .with_labels(validated.recommended_labels(role));
+    builder
 }
 
 #[cfg(test)]

--- a/rust/operator-binary/src/connect/controller/build/rbac.rs
+++ b/rust/operator-binary/src/connect/controller/build/rbac.rs
@@ -17,11 +17,19 @@ stackable_operator::constant!(NONE_ROLE_NAME: RoleName = "none");
 stackable_operator::constant!(NONE_ROLE_GROUP_NAME: RoleGroupName = "none");
 
 pub fn build_service_account(server: &ValidatedSparkConnectServer) -> ServiceAccount {
-    rbac::build_service_account(server, &server.rbac_resource_names(), rbac_labels(server))
+    rbac::build_service_account(
+        server,
+        &server.cluster_resource_names(),
+        rbac_labels(server),
+    )
 }
 
 pub fn build_role_binding(server: &ValidatedSparkConnectServer) -> RoleBinding {
-    rbac::build_role_binding(server, &server.rbac_resource_names(), rbac_labels(server))
+    rbac::build_role_binding(
+        server,
+        &server.cluster_resource_names(),
+        rbac_labels(server),
+    )
 }
 
 fn rbac_labels(server: &ValidatedSparkConnectServer) -> Labels {

--- a/rust/operator-binary/src/connect/controller/build/rbac.rs
+++ b/rust/operator-binary/src/connect/controller/build/rbac.rs
@@ -1,0 +1,29 @@
+//! Builds the RBAC resources (ServiceAccount + RoleBinding) shared by all role groups.
+
+use std::str::FromStr;
+
+use stackable_operator::{
+    k8s_openapi::api::{core::v1::ServiceAccount, rbac::v1::RoleBinding},
+    kvp::Labels,
+    v2::{
+        rbac,
+        types::operator::{RoleGroupName, RoleName},
+    },
+};
+
+use crate::connect::controller::validate::ValidatedSparkConnectServer;
+
+stackable_operator::constant!(NONE_ROLE_NAME: RoleName = "none");
+stackable_operator::constant!(NONE_ROLE_GROUP_NAME: RoleGroupName = "none");
+
+pub fn build_service_account(server: &ValidatedSparkConnectServer) -> ServiceAccount {
+    rbac::build_service_account(server, &server.rbac_resource_names(), rbac_labels(server))
+}
+
+pub fn build_role_binding(server: &ValidatedSparkConnectServer) -> RoleBinding {
+    rbac::build_role_binding(server, &server.rbac_resource_names(), rbac_labels(server))
+}
+
+fn rbac_labels(server: &ValidatedSparkConnectServer) -> Labels {
+    server.recommended_labels_for(&NONE_ROLE_NAME, &NONE_ROLE_GROUP_NAME)
+}

--- a/rust/operator-binary/src/connect/controller/build/rbac.rs
+++ b/rust/operator-binary/src/connect/controller/build/rbac.rs
@@ -35,3 +35,99 @@ pub fn build_role_binding(server: &ValidatedSparkConnectServer) -> RoleBinding {
 fn rbac_labels(server: &ValidatedSparkConnectServer) -> Labels {
     server.recommended_labels_for(&NONE_ROLE_NAME, &NONE_ROLE_GROUP_NAME)
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::{
+        connect::controller::build::test_support::minimal_validated_cluster,
+        test_support::app_version_label,
+    };
+
+    // `my-connect` vs `spark-connect`: see the swap-guard note on `CONNECT_YAML`.
+
+    #[test]
+    fn test_service_account() {
+        let service_account = build_service_account(&minimal_validated_cluster());
+
+        assert_eq!(
+            json!({
+                "apiVersion": "v1",
+                "kind": "ServiceAccount",
+                "metadata": {
+                    // The RBAC resources are cluster-shared, so role and role group are `none`.
+                    "labels": {
+                        "app.kubernetes.io/component": "none",
+                        "app.kubernetes.io/instance": "my-connect",
+                        "app.kubernetes.io/managed-by": "spark.stackable.tech_connect",
+                        "app.kubernetes.io/name": "spark-connect",
+                        "app.kubernetes.io/role-group": "none",
+                        "app.kubernetes.io/version": app_version_label("4.1.2"),
+                        "stackable.tech/vendor": "Stackable"
+                    },
+                    "name": "my-connect-serviceaccount",
+                    "namespace": "default",
+                    "ownerReferences": [
+                        {
+                            "apiVersion": "spark.stackable.tech/v1alpha1",
+                            "controller": true,
+                            "kind": "SparkConnectServer",
+                            "name": "my-connect",
+                            "uid": "12345678-1234-1234-1234-123456789012"
+                        }
+                    ]
+                }
+            }),
+            serde_json::to_value(service_account).expect("must be serializable")
+        );
+    }
+
+    #[test]
+    fn test_role_binding() {
+        let role_binding = build_role_binding(&minimal_validated_cluster());
+
+        assert_eq!(
+            json!({
+                "apiVersion": "rbac.authorization.k8s.io/v1",
+                "kind": "RoleBinding",
+                "metadata": {
+                    "labels": {
+                        "app.kubernetes.io/component": "none",
+                        "app.kubernetes.io/instance": "my-connect",
+                        "app.kubernetes.io/managed-by": "spark.stackable.tech_connect",
+                        "app.kubernetes.io/name": "spark-connect",
+                        "app.kubernetes.io/role-group": "none",
+                        "app.kubernetes.io/version": app_version_label("4.1.2"),
+                        "stackable.tech/vendor": "Stackable"
+                    },
+                    "name": "my-connect-rolebinding",
+                    "namespace": "default",
+                    "ownerReferences": [
+                        {
+                            "apiVersion": "spark.stackable.tech/v1alpha1",
+                            "controller": true,
+                            "kind": "SparkConnectServer",
+                            "name": "my-connect",
+                            "uid": "12345678-1234-1234-1234-123456789012"
+                        }
+                    ]
+                },
+                "roleRef": {
+                    "apiGroup": "rbac.authorization.k8s.io",
+                    "kind": "ClusterRole",
+                    "name": "spark-connect-clusterrole"
+                },
+                "subjects": [
+                    {
+                        "kind": "ServiceAccount",
+                        "name": "my-connect-serviceaccount",
+                        "namespace": "default"
+                    }
+                ]
+            }),
+            serde_json::to_value(role_binding).expect("must be serializable")
+        );
+    }
+}

--- a/rust/operator-binary/src/connect/controller/build/server.rs
+++ b/rust/operator-binary/src/connect/controller/build/server.rs
@@ -190,7 +190,7 @@ pub(crate) fn build_stateful_set(
 
     let mut pb = PodBuilder::new();
 
-    pb.service_account_name(validated.rbac_resource_names().service_account_name())
+    pb.service_account_name(validated.cluster_resource_names().service_account_name())
         .metadata(metadata)
         .image_pull_secrets_from_product_image(resolved_product_image)
         .add_volume(
@@ -403,7 +403,7 @@ pub(crate) fn server_properties(
     let resolved_product_image = &validated.resolved_product_image;
     let spark_image = resolved_product_image.image.clone();
     let spark_version = resolved_product_image.product_version.clone();
-    let service_account_name = validated.rbac_resource_names().service_account_name();
+    let service_account_name = validated.cluster_resource_names().service_account_name();
     let namespace = driver_service
         .namespace()
         .context(ObjectHasNoNamespaceSnafu)?;

--- a/rust/operator-binary/src/connect/controller/build/server.rs
+++ b/rust/operator-binary/src/connect/controller/build/server.rs
@@ -23,10 +23,7 @@ use stackable_operator::{
         DeepMerge,
         api::{
             apps::v1::{StatefulSet, StatefulSetSpec},
-            core::v1::{
-                ConfigMap, EnvVar, HTTPGetAction, PodSecurityContext, Probe, Service,
-                ServiceAccount,
-            },
+            core::v1::{ConfigMap, EnvVar, HTTPGetAction, PodSecurityContext, Probe, Service},
         },
         apimachinery::pkg::{apis::meta::v1::LabelSelector, util::intstr::IntOrString},
     },
@@ -176,7 +173,6 @@ pub(crate) fn server_config_map(
 
 pub(crate) fn build_stateful_set(
     validated: &ValidatedSparkConnectServer,
-    service_account: &ServiceAccount,
     config_map: &ConfigMap,
     listener_name: &str,
     args: Vec<String>,
@@ -194,7 +190,7 @@ pub(crate) fn build_stateful_set(
 
     let mut pb = PodBuilder::new();
 
-    pb.service_account_name(service_account.name_unchecked())
+    pb.service_account_name(validated.rbac_resource_names().service_account_name())
         .metadata(metadata)
         .image_pull_secrets_from_product_image(resolved_product_image)
         .add_volume(
@@ -402,13 +398,12 @@ fn env(env_overrides: Option<&HashMap<String, String>>) -> Result<Vec<EnvVar>, E
 pub(crate) fn server_properties(
     validated: &ValidatedSparkConnectServer,
     driver_service: &Service,
-    service_account: &ServiceAccount,
 ) -> Result<BTreeMap<String, Option<String>>, Error> {
     let config = &validated.server_config;
     let resolved_product_image = &validated.resolved_product_image;
     let spark_image = resolved_product_image.image.clone();
     let spark_version = resolved_product_image.product_version.clone();
-    let service_account_name = service_account.name_unchecked();
+    let service_account_name = validated.rbac_resource_names().service_account_name();
     let namespace = driver_service
         .namespace()
         .context(ObjectHasNoNamespaceSnafu)?;
@@ -434,7 +429,7 @@ pub(crate) fn server_properties(
         ("spark.kubernetes.namespace".to_string(), Some(namespace)),
         (
             "spark.kubernetes.authenticate.driver.serviceAccountName".to_string(),
-            Some(service_account_name),
+            Some(service_account_name.to_string()),
         ),
         (
             "spark.kubernetes.driver.pod.name".to_string(),

--- a/rust/operator-binary/src/connect/controller/build/server.rs
+++ b/rust/operator-binary/src/connect/controller/build/server.rs
@@ -45,7 +45,7 @@ use crate::{
     connect::{
         GRPC, HTTP,
         common::{self, SparkConnectRole, object_name},
-        controller::validate::ValidatedSparkConnectServer,
+        controller::{build::object_meta, validate::ValidatedSparkConnectServer},
         crd::{
             CONNECT_GRPC_PORT, CONNECT_SERVER_ROLE_NAME, CONNECT_UI_PORT,
             DEFAULT_SPARK_CONNECT_GROUP_NAME, SparkConnectContainer, v1alpha1,
@@ -144,11 +144,7 @@ pub(crate) fn server_config_map(
     let mut cm_builder = ConfigMapBuilder::new();
 
     cm_builder
-        .metadata(
-            validated
-                .object_meta(&cm_name, SparkConnectRole::Server)
-                .build(),
-        )
+        .metadata(object_meta(validated, &cm_name, SparkConnectRole::Server).build())
         .add_data(SPARK_DEFAULTS_FILE_NAME, spark_properties)
         .add_data(POD_TEMPLATE_FILE, executor_pod_template_spec)
         .add_data(JVM_SECURITY_PROPERTIES_FILE, jvm_sec_props)
@@ -319,12 +315,12 @@ pub(crate) fn build_stateful_set(
     pod_template.merge_from(validated.server_overrides.pod_overrides.clone());
 
     Ok(StatefulSet {
-        metadata: validated
-            .object_meta(
-                object_name(&validated.name_any(), SparkConnectRole::Server),
-                SparkConnectRole::Server,
-            )
-            .build(),
+        metadata: object_meta(
+            validated,
+            object_name(&validated.name_any(), SparkConnectRole::Server),
+            SparkConnectRole::Server,
+        )
+        .build(),
         spec: Some(StatefulSetSpec {
             template: pod_template,
             replicas: Some(1),

--- a/rust/operator-binary/src/connect/controller/build/service.rs
+++ b/rust/operator-binary/src/connect/controller/build/service.rs
@@ -7,7 +7,7 @@ use stackable_operator::{
 use crate::connect::{
     GRPC, HTTP,
     common::SparkConnectRole,
-    controller::validate::ValidatedSparkConnectServer,
+    controller::{build::object_meta, validate::ValidatedSparkConnectServer},
     crd::{CONNECT_GRPC_PORT, CONNECT_UI_PORT},
 };
 
@@ -23,9 +23,7 @@ pub(crate) fn build_headless_service(validated: &ValidatedSparkConnectServer) ->
     let selector = validated.role_selector(SparkConnectRole::Server).into();
 
     Service {
-        metadata: validated
-            .object_meta(service_name, SparkConnectRole::Server)
-            .build(),
+        metadata: object_meta(validated, service_name, SparkConnectRole::Server).build(),
         spec: Some(ServiceSpec {
             type_: Some("ClusterIP".to_owned()),
             cluster_ip: Some("None".to_owned()),
@@ -63,8 +61,7 @@ pub(crate) fn build_metrics_service(validated: &ValidatedSparkConnectServer) -> 
     let selector = validated.role_selector(SparkConnectRole::Server).into();
 
     Service {
-        metadata: validated
-            .object_meta(service_name, SparkConnectRole::Server)
+        metadata: object_meta(validated, service_name, SparkConnectRole::Server)
             .with_labels(prometheus_labels(&Scraping::Enabled))
             .with_annotations(prometheus_annotations(
                 &Scraping::Enabled,

--- a/rust/operator-binary/src/connect/controller/validate.rs
+++ b/rust/operator-binary/src/connect/controller/validate.rs
@@ -22,7 +22,7 @@ use stackable_operator::{
         product_logging::framework::{
             VectorContainerLogConfig, validate_logging_configuration_for_container,
         },
-        role_utils::JavaCommonConfig,
+        role_utils::{self, JavaCommonConfig},
         types::{
             kubernetes::{ConfigMapName, ListenerClassName, NamespaceName, Uid},
             operator::{
@@ -118,6 +118,10 @@ fn validate_logging(
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
+stackable_operator::constant!(
+    DEFAULT_SPARK_CONNECT_ROLE_GROUP: RoleGroupName = DEFAULT_SPARK_CONNECT_GROUP_NAME
+);
+
 /// Validated logging configuration for the (optional) Vector container.
 ///
 /// Produced up-front by [`validate_logging`] so that an
@@ -134,6 +138,7 @@ pub struct ValidatedSparkConnectServer {
     pub name: ClusterName,
     pub namespace: NamespaceName,
     pub uid: Uid,
+    pub product_version: ProductVersion,
     pub resolved_product_image: ResolvedProductImage,
     pub cluster_config: ValidatedClusterConfig,
     pub role_config: ValidatedRoleConfig,
@@ -167,41 +172,56 @@ pub struct ValidatedRoleConfig {
 }
 
 impl ValidatedSparkConnectServer {
+    /// Recommended labels for a resource that is not tied to a concrete [`SparkConnectRole`]
+    /// (e.g. the cluster-shared RBAC resources), using a free-form role/role-group label value.
+    pub fn recommended_labels_for(
+        &self,
+        role_name: &RoleName,
+        role_group_name: &RoleGroupName,
+    ) -> Labels {
+        self.recommended_labels_with(&self.product_version, role_name, role_group_name)
+    }
+
     /// Recommended labels for a resource of the given role.
-    pub(crate) fn recommended_labels(&self, role: SparkConnectRole) -> Labels {
-        // `app_version_label_value` is constructed to be a valid label value, so it is also a
-        // valid `ProductVersion`.
-        let product_version =
-            ProductVersion::from_str(&self.resolved_product_image.app_version_label_value)
-                .expect("the app version label value is a valid product version");
-        let role_group = RoleGroupName::from_str(DEFAULT_SPARK_CONNECT_GROUP_NAME)
-            .expect("DEFAULT_SPARK_CONNECT_GROUP_NAME is a valid role group name");
+    pub fn recommended_labels(&self, role: SparkConnectRole) -> Labels {
+        self.recommended_labels_for(&role_name(role), &DEFAULT_SPARK_CONNECT_ROLE_GROUP)
+    }
+
+    fn recommended_labels_with(
+        &self,
+        product_version: &ProductVersion,
+        role_name: &RoleName,
+        role_group_name: &RoleGroupName,
+    ) -> Labels {
         recommended_labels(
             self,
             &product_name(),
-            &product_version,
+            product_version,
             &operator_name(),
             &controller_name(),
-            &role_name(role),
-            &role_group,
+            role_name,
+            role_group_name,
         )
     }
 
     /// Selector labels matching the pods of the given role.
-    pub(crate) fn role_selector(&self, role: SparkConnectRole) -> Labels {
+    pub fn role_selector(&self, role: SparkConnectRole) -> Labels {
         role_selector(self, &product_name(), &role_name(role))
     }
 
     /// Selector labels matching the pods of the given role's (single) role group.
-    pub(crate) fn role_group_selector(&self, role: SparkConnectRole) -> Labels {
-        let role_group = RoleGroupName::from_str(DEFAULT_SPARK_CONNECT_GROUP_NAME)
-            .expect("DEFAULT_SPARK_CONNECT_GROUP_NAME is a valid role group name");
-        role_group_selector(self, &product_name(), &role_name(role), &role_group)
+    pub fn role_group_selector(&self, role: SparkConnectRole) -> Labels {
+        role_group_selector(
+            self,
+            &product_name(),
+            &role_name(role),
+            &DEFAULT_SPARK_CONNECT_ROLE_GROUP,
+        )
     }
 
     /// Object metadata for a child resource named `name`, owned by this SparkConnectServer and
     /// carrying the recommended labels for the given role.
-    pub(crate) fn object_meta(
+    pub fn object_meta(
         &self,
         name: impl Into<String>,
         role: SparkConnectRole,
@@ -214,20 +234,29 @@ impl ValidatedSparkConnectServer {
             .with_labels(self.recommended_labels(role));
         builder
     }
+
+    /// Type-safe names for the per-cluster RBAC resources: the ServiceAccount,
+    /// its (namespaced) RoleBinding, and the operator-deployed ClusterRole it binds.
+    pub fn rbac_resource_names(&self) -> role_utils::ResourceNames {
+        role_utils::ResourceNames {
+            cluster_name: self.name.clone(),
+            product_name: product_name(),
+        }
+    }
 }
 
 /// The product name (`spark-connect`) as a type-safe label value.
-pub(crate) fn product_name() -> ProductName {
+pub fn product_name() -> ProductName {
     ProductName::from_str(CONNECT_APP_NAME).expect("CONNECT_APP_NAME is a valid product name")
 }
 
 /// The operator name as a type-safe label value.
-pub(crate) fn operator_name() -> OperatorName {
+pub fn operator_name() -> OperatorName {
     OperatorName::from_str(OPERATOR_NAME).expect("the operator name is a valid label value")
 }
 
 /// The controller name as a type-safe label value.
-pub(crate) fn controller_name() -> ControllerName {
+pub fn controller_name() -> ControllerName {
     ControllerName::from_str(CONNECT_CONTROLLER_NAME)
         .expect("the controller name is a valid label value")
 }
@@ -304,6 +333,9 @@ pub fn validate(
         )
         .context(ResolveProductImageSnafu)?;
 
+    let product_version = ProductVersion::from_str(&resolved_product_image.app_version_label_value)
+        .expect("the app version label value is a valid product version");
+
     let server_config = scs.server_config().context(ServerConfigSnafu)?;
     let executor_config = scs.executor_config().context(ExecutorConfigSnafu)?;
 
@@ -350,6 +382,7 @@ pub fn validate(
         name,
         namespace,
         uid,
+        product_version,
         resolved_product_image,
         cluster_config: ValidatedClusterConfig {
             resolved_s3: dereferenced.resolved_s3,

--- a/rust/operator-binary/src/connect/controller/validate.rs
+++ b/rust/operator-binary/src/connect/controller/validate.rs
@@ -369,3 +369,54 @@ pub fn validate(
         executor_logging,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        connect::controller::build::test_support::minimal_validated_cluster,
+        test_support::app_version_label,
+    };
+
+    /// Locks every value the validate step itself derives from the minimal fixture — so a
+    /// validation regression fails here, with a validate-shaped message, instead of surfacing as
+    /// a confusing build-test failure downstream.
+    #[test]
+    fn validate_ok_derives_expected_values() {
+        let validated = minimal_validated_cluster();
+
+        assert_eq!(validated.name.to_string(), "my-connect");
+        assert_eq!(validated.namespace.to_string(), "default");
+        assert_eq!(
+            validated.uid.to_string(),
+            "12345678-1234-1234-1234-123456789012"
+        );
+        assert_eq!(
+            validated.resolved_product_image.image,
+            format!(
+                "oci.example.org/sdp/spark-k8s:{}",
+                app_version_label("4.1.2")
+            )
+        );
+        assert_eq!(validated.resolved_product_image.product_version, "4.1.2");
+        assert_eq!(
+            validated.product_version.to_string(),
+            app_version_label("4.1.2")
+        );
+
+        // The role config falls back to the default cluster-internal listener.
+        assert_eq!(
+            validated.role_config.listener_class.to_string(),
+            "cluster-internal"
+        );
+
+        // The minimal fixture has no overrides and no Vector agent for either role.
+        for overrides in [&validated.server_overrides, &validated.executor_overrides] {
+            assert!(overrides.env_overrides.is_empty());
+            assert_eq!(overrides.jvm_config, None);
+        }
+        for logging in [&validated.server_logging, &validated.executor_logging] {
+            assert!(!logging.enable_vector_agent);
+            assert_eq!(logging.vector_container, None);
+        }
+    }
+}

--- a/rust/operator-binary/src/connect/controller/validate.rs
+++ b/rust/operator-binary/src/connect/controller/validate.rs
@@ -237,7 +237,7 @@ impl ValidatedSparkConnectServer {
 
     /// Type-safe names for the per-cluster RBAC resources: the ServiceAccount,
     /// its (namespaced) RoleBinding, and the operator-deployed ClusterRole it binds.
-    pub fn rbac_resource_names(&self) -> role_utils::ResourceNames {
+    pub fn cluster_resource_names(&self) -> role_utils::ResourceNames {
         role_utils::ResourceNames {
             cluster_name: self.name.clone(),
             product_name: product_name(),

--- a/rust/operator-binary/src/connect/controller/validate.rs
+++ b/rust/operator-binary/src/connect/controller/validate.rs
@@ -38,9 +38,8 @@ use crate::{
         common::SparkConnectRole,
         controller::dereference::DereferencedSparkConnectServer,
         crd::{
-            self, CONNECT_APP_NAME, CONNECT_CONTROLLER_NAME, CONNECT_EXECUTOR_ROLE_NAME,
-            CONNECT_SERVER_ROLE_NAME, DEFAULT_SPARK_CONNECT_GROUP_NAME, SparkConnectContainer,
-            v1alpha1,
+            self, CONNECT_APP_NAME, CONNECT_CONTROLLER_NAME, DEFAULT_SPARK_CONNECT_GROUP_NAME,
+            SparkConnectContainer, v1alpha1,
         },
         s3::ResolvedS3,
     },
@@ -184,7 +183,7 @@ impl ValidatedSparkConnectServer {
 
     /// Recommended labels for a resource of the given role.
     pub fn recommended_labels(&self, role: SparkConnectRole) -> Labels {
-        self.recommended_labels_for(&role_name(role), &DEFAULT_SPARK_CONNECT_ROLE_GROUP)
+        self.recommended_labels_for(&role.into(), &DEFAULT_SPARK_CONNECT_ROLE_GROUP)
     }
 
     fn recommended_labels_with(
@@ -206,7 +205,7 @@ impl ValidatedSparkConnectServer {
 
     /// Selector labels matching the pods of the given role.
     pub fn role_selector(&self, role: SparkConnectRole) -> Labels {
-        role_selector(self, &product_name(), &role_name(role))
+        role_selector(self, &product_name(), &role.into())
     }
 
     /// Selector labels matching the pods of the given role's (single) role group.
@@ -214,7 +213,7 @@ impl ValidatedSparkConnectServer {
         role_group_selector(
             self,
             &product_name(),
-            &role_name(role),
+            &role.into(),
             &DEFAULT_SPARK_CONNECT_ROLE_GROUP,
         )
     }
@@ -259,16 +258,6 @@ pub fn operator_name() -> OperatorName {
 pub fn controller_name() -> ControllerName {
     ControllerName::from_str(CONNECT_CONTROLLER_NAME)
         .expect("the controller name is a valid label value")
-}
-
-/// The role name for the given Spark Connect role as a type-safe label value.
-fn role_name(role: SparkConnectRole) -> RoleName {
-    match role {
-        SparkConnectRole::Server => RoleName::from_str(CONNECT_SERVER_ROLE_NAME)
-            .expect("CONNECT_SERVER_ROLE_NAME is a valid role name"),
-        SparkConnectRole::Executor => RoleName::from_str(CONNECT_EXECUTOR_ROLE_NAME)
-            .expect("CONNECT_EXECUTOR_ROLE_NAME is a valid role name"),
-    }
 }
 
 impl NameIsValidLabelValue for ValidatedSparkConnectServer {

--- a/rust/operator-binary/src/connect/controller/validate.rs
+++ b/rust/operator-binary/src/connect/controller/validate.rs
@@ -7,7 +7,6 @@ use std::{borrow::Cow, collections::HashMap, str::FromStr};
 
 use snafu::{OptionExt, ResultExt, Snafu};
 use stackable_operator::{
-    builder::meta::ObjectMetaBuilder,
     cli::OperatorEnvironmentOptions,
     commons::product_image_selection::{self, ResolvedProductImage},
     k8s_openapi::{api::core::v1::PodTemplateSpec, apimachinery::pkg::apis::meta::v1::ObjectMeta},
@@ -16,7 +15,6 @@ use stackable_operator::{
     product_logging::spec::Logging,
     v2::{
         HasName, HasUid, NameIsValidLabelValue,
-        builder::meta::ownerreference_from_resource,
         controller_utils::{get_cluster_name, get_namespace, get_uid},
         kvp::label::{recommended_labels, role_group_selector, role_selector},
         product_logging::framework::{
@@ -216,22 +214,6 @@ impl ValidatedSparkConnectServer {
             &role.into(),
             &DEFAULT_SPARK_CONNECT_ROLE_GROUP,
         )
-    }
-
-    /// Object metadata for a child resource named `name`, owned by this SparkConnectServer and
-    /// carrying the recommended labels for the given role.
-    pub fn object_meta(
-        &self,
-        name: impl Into<String>,
-        role: SparkConnectRole,
-    ) -> ObjectMetaBuilder {
-        let mut builder = ObjectMetaBuilder::new();
-        builder
-            .name_and_namespace(self)
-            .name(name)
-            .ownerreference(ownerreference_from_resource(self, None, Some(true)))
-            .with_labels(self.recommended_labels(role));
-        builder
     }
 
     /// Type-safe names for the per-cluster RBAC resources: the ServiceAccount,

--- a/rust/operator-binary/src/connect/s3.rs
+++ b/rust/operator-binary/src/connect/s3.rs
@@ -54,6 +54,16 @@ pub(crate) struct ResolvedS3 {
 }
 
 impl ResolvedS3 {
+    /// The resolved form of a SparkConnectServer without any S3 connectors, for tests that must
+    /// stay client-free.
+    #[cfg(test)]
+    pub(crate) fn none() -> Self {
+        Self {
+            s3_buckets: Vec::new(),
+            s3_connection: None,
+        }
+    }
+
     pub(crate) async fn resolve(
         client: &stackable_operator::client::Client,
         connect_server: &crd::v1alpha1::SparkConnectServer,

--- a/rust/operator-binary/src/history/controller.rs
+++ b/rust/operator-binary/src/history/controller.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use snafu::{ResultExt, Snafu};
 use stackable_operator::{
     cluster_resources::ClusterResourceApplyStrategy,
-    commons::rbac::build_rbac_resources,
     crd::listener,
     k8s_openapi::api::{
         apps::v1::StatefulSet,
@@ -21,10 +20,7 @@ use stackable_operator::{
 };
 use strum::{EnumDiscriminants, IntoStaticStr};
 
-use crate::{
-    Ctx,
-    crd::{constants::HISTORY_APP_NAME, history::v1alpha1},
-};
+use crate::{Ctx, crd::history::v1alpha1};
 
 pub mod build;
 pub mod dereference;
@@ -34,26 +30,11 @@ pub mod validate;
 #[strum_discriminants(derive(IntoStaticStr))]
 #[allow(clippy::enum_variant_names)]
 pub enum Error {
-    #[snafu(display("failed to build RBAC resources"))]
-    BuildRbacResources {
-        source: stackable_operator::commons::rbac::Error,
-    },
-
     #[snafu(display("failed to build SparkHistoryServer resources"))]
     BuildSparkHistoryServer { source: build::Error },
 
     #[snafu(display("failed to apply Kubernetes resource"))]
     ApplyResource {
-        source: stackable_operator::cluster_resources::Error,
-    },
-
-    #[snafu(display("failed to apply role ServiceAccount"))]
-    ApplyServiceAccount {
-        source: stackable_operator::cluster_resources::Error,
-    },
-
-    #[snafu(display("failed to apply global RoleBinding"))]
-    ApplyRoleBinding {
         source: stackable_operator::cluster_resources::Error,
     },
 
@@ -66,12 +47,6 @@ pub enum Error {
     #[snafu(display("failed to delete orphaned resources"))]
     DeleteOrphanedResources {
         source: stackable_operator::cluster_resources::Error,
-    },
-
-    #[snafu(display("failed to get required Labels"))]
-    GetRequiredLabels {
-        source:
-            stackable_operator::kvp::KeyValuePairError<stackable_operator::kvp::LabelValueError>,
     },
 
     #[snafu(display("SparkHistoryServer object is invalid"))]
@@ -135,20 +110,7 @@ pub async fn reconcile(
         &shs.spec.object_overrides,
     );
 
-    // Use a dedicated service account for history server pods. Building the RBAC resources needs
-    // the cluster-resource labels, so it stays in the reconcile step; the built objects (whose
-    // names are deterministic) are handed to the client-free build step.
-    let (service_account, role_binding) = build_rbac_resources(
-        shs,
-        HISTORY_APP_NAME,
-        cluster_resources
-            .get_required_labels()
-            .context(GetRequiredLabelsSnafu)?,
-    )
-    .context(BuildRbacResourcesSnafu)?;
-
-    let resources = build::build(&validated, service_account, role_binding)
-        .context(BuildSparkHistoryServerSnafu)?;
+    let resources = build::build(&validated).context(BuildSparkHistoryServerSnafu)?;
 
     // Apply order: ServiceAccount and RoleBinding first, then the ConfigMaps, metrics Services,
     // Listener and PodDisruptionBudget, and finally the StatefulSets (they mount the ConfigMaps
@@ -156,11 +118,11 @@ pub async fn reconcile(
     cluster_resources
         .add(client, resources.service_account)
         .await
-        .context(ApplyServiceAccountSnafu)?;
+        .context(ApplyResourceSnafu)?;
     cluster_resources
         .add(client, resources.role_binding)
         .await
-        .context(ApplyRoleBindingSnafu)?;
+        .context(ApplyResourceSnafu)?;
     for config_map in resources.config_maps {
         cluster_resources
             .add(client, config_map)

--- a/rust/operator-binary/src/history/controller/build/mod.rs
+++ b/rust/operator-binary/src/history/controller/build/mod.rs
@@ -67,13 +67,10 @@ pub fn build(validated: &ValidatedSparkHistoryServer) -> Result<SparkHistoryReso
 }
 
 #[cfg(test)]
-mod tests {
-    use std::collections::BTreeMap;
-
+pub(crate) mod test_support {
     use indoc::indoc;
     use stackable_operator::{cli::OperatorEnvironmentOptions, utils::yaml_from_str_singleton_map};
 
-    use super::build;
     use crate::{
         crd::{history::v1alpha1, logdir::ResolvedLogDir},
         history::controller::{
@@ -84,7 +81,11 @@ mod tests {
 
     /// Minimal custom-log-dir `SparkHistoryServer` fixture. The custom log directory keeps the
     /// dereference step client-free; the `uid` allows owner references to be derived from it.
-    const HISTORY_YAML: &str = indoc! {r#"
+    ///
+    /// The cluster name (`my-history`) deliberately differs from the product name
+    /// (`spark-history`), so tests asserting recommended labels catch swapped `name`/`instance`
+    /// values.
+    pub const HISTORY_YAML: &str = indoc! {r#"
         apiVersion: spark.stackable.tech/v1alpha1
         kind: SparkHistoryServer
         metadata:
@@ -103,7 +104,7 @@ mod tests {
         "#};
 
     /// Runs the real validate step against the minimal fixture.
-    fn minimal_validated_cluster() -> ValidatedSparkHistoryServer {
+    pub fn minimal_validated_cluster() -> ValidatedSparkHistoryServer {
         let shs: v1alpha1::SparkHistoryServer = yaml_from_str_singleton_map(HISTORY_YAML)
             .expect("invalid test SparkHistoryServer YAML");
         validate(
@@ -118,50 +119,5 @@ mod tests {
             },
         )
         .expect("validate should succeed for the test fixture")
-    }
-
-    /// Locks the RBAC resource names, the roleRef, and the recommended label set against
-    /// accidental drift. The fixture's cluster name deliberately differs from the product name so
-    /// that swapped `name`/`instance` label values cannot pass unnoticed.
-    #[test]
-    fn build_produces_rbac() {
-        let resources = build(&minimal_validated_cluster()).expect("build succeeds");
-
-        assert_eq!(
-            resources.service_account.metadata.name.as_deref(),
-            Some("my-history-serviceaccount")
-        );
-        assert_eq!(
-            resources.role_binding.metadata.name.as_deref(),
-            Some("my-history-rolebinding")
-        );
-
-        let expected_labels = BTreeMap::from(
-            [
-                ("app.kubernetes.io/component", "none"),
-                ("app.kubernetes.io/instance", "my-history"),
-                (
-                    "app.kubernetes.io/managed-by",
-                    "spark.stackable.tech_history",
-                ),
-                ("app.kubernetes.io/name", "spark-history"),
-                ("app.kubernetes.io/role-group", "none"),
-                ("app.kubernetes.io/version", "3.5.8-stackable0.0.0-dev"),
-                ("stackable.tech/vendor", "Stackable"),
-            ]
-            .map(|(key, value)| (key.to_string(), value.to_string())),
-        );
-        assert_eq!(
-            resources.service_account.metadata.labels,
-            Some(expected_labels.clone())
-        );
-        assert_eq!(
-            resources.role_binding.metadata.labels,
-            Some(expected_labels)
-        );
-        assert_eq!(
-            resources.role_binding.role_ref.name,
-            "spark-history-clusterrole"
-        );
     }
 }

--- a/rust/operator-binary/src/history/controller/build/mod.rs
+++ b/rust/operator-binary/src/history/controller/build/mod.rs
@@ -1,7 +1,6 @@
 pub mod resource;
 
 use snafu::{ResultExt, Snafu};
-use stackable_operator::k8s_openapi::api::{core::v1::ServiceAccount, rbac::v1::RoleBinding};
 
 use crate::{
     crd::constants::HISTORY_ROLE_NAME,
@@ -11,6 +10,7 @@ use crate::{
             config_map::{self, build_config_map},
             listener::build_group_listener,
             pdb::build_pdb,
+            rbac::{build_role_binding, build_service_account},
             service::build_rolegroup_metrics_service,
             statefulset::{self, build_stateful_set},
         },
@@ -30,11 +30,7 @@ pub enum Error {
 type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Builds every Kubernetes resource for the given validated SparkHistoryServer.
-pub fn build(
-    validated: &ValidatedSparkHistoryServer,
-    service_account: ServiceAccount,
-    role_binding: RoleBinding,
-) -> Result<SparkHistoryResources> {
+pub fn build(validated: &ValidatedSparkHistoryServer) -> Result<SparkHistoryResources> {
     let log_dir = &validated.cluster_config.log_dir;
 
     let mut config_maps = vec![];
@@ -46,7 +42,7 @@ pub fn build(
             .push(build_config_map(validated, role_group_name, rg).context(BuildConfigMapSnafu)?);
         metrics_services.push(build_rolegroup_metrics_service(validated, role_group_name));
         stateful_sets.push(
-            build_stateful_set(validated, role_group_name, rg, log_dir, &service_account)
+            build_stateful_set(validated, role_group_name, rg, log_dir)
                 .context(BuildStatefulSetSnafu)?,
         );
     }
@@ -60,12 +56,112 @@ pub fn build(
     let pod_disruption_budget = build_pdb(&validated.role_config.pdb, validated);
 
     Ok(SparkHistoryResources {
-        service_account,
-        role_binding,
+        service_account: build_service_account(validated),
+        role_binding: build_role_binding(validated),
         config_maps,
         metrics_services,
         stateful_sets,
         listener,
         pod_disruption_budget,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use indoc::indoc;
+    use stackable_operator::{cli::OperatorEnvironmentOptions, utils::yaml_from_str_singleton_map};
+
+    use super::build;
+    use crate::{
+        crd::{history::v1alpha1, logdir::ResolvedLogDir},
+        history::controller::{
+            dereference::DereferencedSparkHistoryServer,
+            validate::{ValidatedSparkHistoryServer, validate},
+        },
+    };
+
+    /// Minimal custom-log-dir `SparkHistoryServer` fixture. The custom log directory keeps the
+    /// dereference step client-free; the `uid` allows owner references to be derived from it.
+    const HISTORY_YAML: &str = indoc! {r#"
+        apiVersion: spark.stackable.tech/v1alpha1
+        kind: SparkHistoryServer
+        metadata:
+          name: my-history
+          namespace: default
+          uid: 12345678-1234-1234-1234-123456789012
+        spec:
+          image:
+            productVersion: 3.5.8
+          logFileDirectory:
+            customLogDirectory: file:///stackable/spark/logs
+          nodes:
+            roleGroups:
+              default:
+                replicas: 1
+        "#};
+
+    /// Runs the real validate step against the minimal fixture.
+    fn minimal_validated_cluster() -> ValidatedSparkHistoryServer {
+        let shs: v1alpha1::SparkHistoryServer = yaml_from_str_singleton_map(HISTORY_YAML)
+            .expect("invalid test SparkHistoryServer YAML");
+        validate(
+            &shs,
+            DereferencedSparkHistoryServer {
+                log_dir: ResolvedLogDir::Custom("file:///stackable/spark/logs".to_string()),
+            },
+            &OperatorEnvironmentOptions {
+                operator_namespace: "stackable-operators".to_string(),
+                operator_service_name: "spark-k8s-operator".to_string(),
+                image_repository: "oci.example.org/sdp".to_string(),
+            },
+        )
+        .expect("validate should succeed for the test fixture")
+    }
+
+    /// Locks the RBAC resource names, the roleRef, and the recommended label set against
+    /// accidental drift. The fixture's cluster name deliberately differs from the product name so
+    /// that swapped `name`/`instance` label values cannot pass unnoticed.
+    #[test]
+    fn build_produces_rbac() {
+        let resources = build(&minimal_validated_cluster()).expect("build succeeds");
+
+        assert_eq!(
+            resources.service_account.metadata.name.as_deref(),
+            Some("my-history-serviceaccount")
+        );
+        assert_eq!(
+            resources.role_binding.metadata.name.as_deref(),
+            Some("my-history-rolebinding")
+        );
+
+        let expected_labels = BTreeMap::from(
+            [
+                ("app.kubernetes.io/component", "none"),
+                ("app.kubernetes.io/instance", "my-history"),
+                (
+                    "app.kubernetes.io/managed-by",
+                    "spark.stackable.tech_history",
+                ),
+                ("app.kubernetes.io/name", "spark-history"),
+                ("app.kubernetes.io/role-group", "none"),
+                ("app.kubernetes.io/version", "3.5.8-stackable0.0.0-dev"),
+                ("stackable.tech/vendor", "Stackable"),
+            ]
+            .map(|(key, value)| (key.to_string(), value.to_string())),
+        );
+        assert_eq!(
+            resources.service_account.metadata.labels,
+            Some(expected_labels.clone())
+        );
+        assert_eq!(
+            resources.role_binding.metadata.labels,
+            Some(expected_labels)
+        );
+        assert_eq!(
+            resources.role_binding.role_ref.name,
+            "spark-history-clusterrole"
+        );
+    }
 }

--- a/rust/operator-binary/src/history/controller/build/mod.rs
+++ b/rust/operator-binary/src/history/controller/build/mod.rs
@@ -1,6 +1,10 @@
 pub mod resource;
 
 use snafu::{ResultExt, Snafu};
+use stackable_operator::{
+    builder::meta::ObjectMetaBuilder,
+    v2::{builder::meta::ownerreference_from_resource, types::operator::RoleGroupName},
+};
 
 use crate::{
     crd::constants::HISTORY_ROLE_NAME,
@@ -64,6 +68,23 @@ pub fn build(validated: &ValidatedSparkHistoryServer) -> Result<SparkHistoryReso
         listener,
         pod_disruption_budget,
     })
+}
+
+/// Object metadata for a child resource named `name`, owned by the SparkHistoryServer and
+/// carrying the recommended labels for the given role group. Returns the builder so callers can
+/// add extra labels (e.g. Prometheus annotations) before building.
+pub(crate) fn object_meta(
+    validated: &ValidatedSparkHistoryServer,
+    name: impl Into<String>,
+    role_group_name: &RoleGroupName,
+) -> ObjectMetaBuilder {
+    let mut builder = ObjectMetaBuilder::new();
+    builder
+        .name_and_namespace(validated)
+        .name(name)
+        .ownerreference(ownerreference_from_resource(validated, None, Some(true)))
+        .with_labels(validated.recommended_labels(role_group_name));
+    builder
 }
 
 #[cfg(test)]

--- a/rust/operator-binary/src/history/controller/build/resource/config_map.rs
+++ b/rust/operator-binary/src/history/controller/build/resource/config_map.rs
@@ -55,7 +55,7 @@ pub(crate) fn build_config_map(
     rg: &ValidatedHistoryRoleGroup,
 ) -> Result<ConfigMap> {
     let cm_name = validated
-        .resource_names(role_group_name)
+        .role_group_resource_names(role_group_name)
         .role_group_config_map()
         .to_string();
 

--- a/rust/operator-binary/src/history/controller/build/resource/mod.rs
+++ b/rust/operator-binary/src/history/controller/build/resource/mod.rs
@@ -1,5 +1,6 @@
 pub mod config_map;
 pub mod listener;
 pub mod pdb;
+pub mod rbac;
 pub mod service;
 pub mod statefulset;

--- a/rust/operator-binary/src/history/controller/build/resource/rbac.rs
+++ b/rust/operator-binary/src/history/controller/build/resource/rbac.rs
@@ -17,11 +17,19 @@ stackable_operator::constant!(NONE_ROLE_NAME: RoleName = "none");
 stackable_operator::constant!(NONE_ROLE_GROUP_NAME: RoleGroupName = "none");
 
 pub fn build_service_account(server: &ValidatedSparkHistoryServer) -> ServiceAccount {
-    rbac::build_service_account(server, &server.rbac_resource_names(), rbac_labels(server))
+    rbac::build_service_account(
+        server,
+        &server.cluster_resource_names(),
+        rbac_labels(server),
+    )
 }
 
 pub fn build_role_binding(server: &ValidatedSparkHistoryServer) -> RoleBinding {
-    rbac::build_role_binding(server, &server.rbac_resource_names(), rbac_labels(server))
+    rbac::build_role_binding(
+        server,
+        &server.cluster_resource_names(),
+        rbac_labels(server),
+    )
 }
 
 fn rbac_labels(server: &ValidatedSparkHistoryServer) -> Labels {

--- a/rust/operator-binary/src/history/controller/build/resource/rbac.rs
+++ b/rust/operator-binary/src/history/controller/build/resource/rbac.rs
@@ -1,0 +1,29 @@
+//! Builds the RBAC resources (ServiceAccount + RoleBinding) shared by all role groups.
+
+use std::str::FromStr;
+
+use stackable_operator::{
+    k8s_openapi::api::{core::v1::ServiceAccount, rbac::v1::RoleBinding},
+    kvp::Labels,
+    v2::{
+        rbac,
+        types::operator::{RoleGroupName, RoleName},
+    },
+};
+
+use crate::history::controller::validate::ValidatedSparkHistoryServer;
+
+stackable_operator::constant!(NONE_ROLE_NAME: RoleName = "none");
+stackable_operator::constant!(NONE_ROLE_GROUP_NAME: RoleGroupName = "none");
+
+pub fn build_service_account(server: &ValidatedSparkHistoryServer) -> ServiceAccount {
+    rbac::build_service_account(server, &server.rbac_resource_names(), rbac_labels(server))
+}
+
+pub fn build_role_binding(server: &ValidatedSparkHistoryServer) -> RoleBinding {
+    rbac::build_role_binding(server, &server.rbac_resource_names(), rbac_labels(server))
+}
+
+fn rbac_labels(server: &ValidatedSparkHistoryServer) -> Labels {
+    server.recommended_labels_for(&NONE_ROLE_NAME, &NONE_ROLE_GROUP_NAME)
+}

--- a/rust/operator-binary/src/history/controller/build/resource/rbac.rs
+++ b/rust/operator-binary/src/history/controller/build/resource/rbac.rs
@@ -35,3 +35,99 @@ pub fn build_role_binding(server: &ValidatedSparkHistoryServer) -> RoleBinding {
 fn rbac_labels(server: &ValidatedSparkHistoryServer) -> Labels {
     server.recommended_labels_for(&NONE_ROLE_NAME, &NONE_ROLE_GROUP_NAME)
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::{
+        history::controller::build::test_support::minimal_validated_cluster,
+        test_support::app_version_label,
+    };
+
+    // `my-history` vs `spark-history`: see the swap-guard note on `HISTORY_YAML`.
+
+    #[test]
+    fn test_service_account() {
+        let service_account = build_service_account(&minimal_validated_cluster());
+
+        assert_eq!(
+            json!({
+                "apiVersion": "v1",
+                "kind": "ServiceAccount",
+                "metadata": {
+                    // The RBAC resources are cluster-shared, so role and role group are `none`.
+                    "labels": {
+                        "app.kubernetes.io/component": "none",
+                        "app.kubernetes.io/instance": "my-history",
+                        "app.kubernetes.io/managed-by": "spark.stackable.tech_history",
+                        "app.kubernetes.io/name": "spark-history",
+                        "app.kubernetes.io/role-group": "none",
+                        "app.kubernetes.io/version": app_version_label("3.5.8"),
+                        "stackable.tech/vendor": "Stackable"
+                    },
+                    "name": "my-history-serviceaccount",
+                    "namespace": "default",
+                    "ownerReferences": [
+                        {
+                            "apiVersion": "spark.stackable.tech/v1alpha1",
+                            "controller": true,
+                            "kind": "SparkHistoryServer",
+                            "name": "my-history",
+                            "uid": "12345678-1234-1234-1234-123456789012"
+                        }
+                    ]
+                }
+            }),
+            serde_json::to_value(service_account).expect("must be serializable")
+        );
+    }
+
+    #[test]
+    fn test_role_binding() {
+        let role_binding = build_role_binding(&minimal_validated_cluster());
+
+        assert_eq!(
+            json!({
+                "apiVersion": "rbac.authorization.k8s.io/v1",
+                "kind": "RoleBinding",
+                "metadata": {
+                    "labels": {
+                        "app.kubernetes.io/component": "none",
+                        "app.kubernetes.io/instance": "my-history",
+                        "app.kubernetes.io/managed-by": "spark.stackable.tech_history",
+                        "app.kubernetes.io/name": "spark-history",
+                        "app.kubernetes.io/role-group": "none",
+                        "app.kubernetes.io/version": app_version_label("3.5.8"),
+                        "stackable.tech/vendor": "Stackable"
+                    },
+                    "name": "my-history-rolebinding",
+                    "namespace": "default",
+                    "ownerReferences": [
+                        {
+                            "apiVersion": "spark.stackable.tech/v1alpha1",
+                            "controller": true,
+                            "kind": "SparkHistoryServer",
+                            "name": "my-history",
+                            "uid": "12345678-1234-1234-1234-123456789012"
+                        }
+                    ]
+                },
+                "roleRef": {
+                    "apiGroup": "rbac.authorization.k8s.io",
+                    "kind": "ClusterRole",
+                    "name": "spark-history-clusterrole"
+                },
+                "subjects": [
+                    {
+                        "kind": "ServiceAccount",
+                        "name": "my-history-serviceaccount",
+                        "namespace": "default"
+                    }
+                ]
+            }),
+            serde_json::to_value(role_binding).expect("must be serializable")
+        );
+    }
+}

--- a/rust/operator-binary/src/history/controller/build/resource/service.rs
+++ b/rust/operator-binary/src/history/controller/build/resource/service.rs
@@ -53,3 +53,81 @@ fn metrics_ports() -> Vec<ServicePort> {
         ..ServicePort::default()
     }]
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use stackable_operator::v2::types::operator::RoleGroupName;
+
+    use super::*;
+    use crate::{
+        history::controller::build::test_support::minimal_validated_cluster,
+        test_support::app_version_label,
+    };
+
+    /// Every metrics Service must carry the Prometheus scrape label and the
+    /// `prometheus.io/path|port|scheme|scrape` annotations, or Prometheus stops discovering the
+    /// endpoints.
+    #[test]
+    fn test_rolegroup_metrics_service() {
+        let validated = minimal_validated_cluster();
+        let role_group_name: RoleGroupName = "default".parse().expect("valid role group name");
+
+        let service = build_rolegroup_metrics_service(&validated, &role_group_name);
+
+        assert_eq!(
+            json!({
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "prometheus.io/path": "/metrics",
+                        "prometheus.io/port": "18081",
+                        "prometheus.io/scheme": "http",
+                        "prometheus.io/scrape": "true"
+                    },
+                    "labels": {
+                        "app.kubernetes.io/component": "node",
+                        "app.kubernetes.io/instance": "my-history",
+                        "app.kubernetes.io/managed-by": "spark.stackable.tech_history",
+                        "app.kubernetes.io/name": "spark-history",
+                        "app.kubernetes.io/role-group": "default",
+                        "app.kubernetes.io/version": app_version_label("3.5.8"),
+                        "prometheus.io/scrape": "true",
+                        "stackable.tech/vendor": "Stackable"
+                    },
+                    "name": "my-history-node-default-metrics",
+                    "namespace": "default",
+                    "ownerReferences": [
+                        {
+                            "apiVersion": "spark.stackable.tech/v1alpha1",
+                            "controller": true,
+                            "kind": "SparkHistoryServer",
+                            "name": "my-history",
+                            "uid": "12345678-1234-1234-1234-123456789012"
+                        }
+                    ]
+                },
+                "spec": {
+                    "clusterIP": "None",
+                    "ports": [
+                        {
+                            "name": "metrics",
+                            "port": 18081,
+                            "protocol": "TCP"
+                        }
+                    ],
+                    "publishNotReadyAddresses": true,
+                    "selector": {
+                        "app.kubernetes.io/component": "node",
+                        "app.kubernetes.io/instance": "my-history",
+                        "app.kubernetes.io/name": "spark-history",
+                        "app.kubernetes.io/role-group": "default"
+                    },
+                    "type": "ClusterIP"
+                }
+            }),
+            serde_json::to_value(service).expect("must be serializable")
+        );
+    }
+}

--- a/rust/operator-binary/src/history/controller/build/resource/service.rs
+++ b/rust/operator-binary/src/history/controller/build/resource/service.rs
@@ -19,7 +19,7 @@ pub fn build_rolegroup_metrics_service(
         metadata: validated
             .object_meta(
                 validated
-                    .resource_names(role_group_name)
+                    .role_group_resource_names(role_group_name)
                     .metrics_service_name()
                     .to_string(),
                 role_group_name,

--- a/rust/operator-binary/src/history/controller/build/resource/service.rs
+++ b/rust/operator-binary/src/history/controller/build/resource/service.rs
@@ -7,7 +7,8 @@ use stackable_operator::{
 };
 
 use crate::{
-    crd::constants::METRICS_PORT, history::controller::validate::ValidatedSparkHistoryServer,
+    crd::constants::METRICS_PORT,
+    history::controller::{build::object_meta, validate::ValidatedSparkHistoryServer},
 };
 
 /// The rolegroup metrics [`Service`] is a service that exposes metrics and a prometheus scraping label
@@ -16,22 +17,22 @@ pub fn build_rolegroup_metrics_service(
     role_group_name: &RoleGroupName,
 ) -> Service {
     Service {
-        metadata: validated
-            .object_meta(
-                validated
-                    .role_group_resource_names(role_group_name)
-                    .metrics_service_name()
-                    .to_string(),
-                role_group_name,
-            )
-            .with_labels(prometheus_labels(&Scraping::Enabled))
-            .with_annotations(prometheus_annotations(
-                &Scraping::Enabled,
-                &Scheme::Http,
-                "/metrics",
-                &METRICS_PORT,
-            ))
-            .build(),
+        metadata: object_meta(
+            validated,
+            validated
+                .role_group_resource_names(role_group_name)
+                .metrics_service_name()
+                .to_string(),
+            role_group_name,
+        )
+        .with_labels(prometheus_labels(&Scraping::Enabled))
+        .with_annotations(prometheus_annotations(
+            &Scraping::Enabled,
+            &Scheme::Http,
+            "/metrics",
+            &METRICS_PORT,
+        ))
+        .build(),
         spec: Some(ServiceSpec {
             // Internal communication does not need to be exposed
             type_: Some("ClusterIP".to_string()),

--- a/rust/operator-binary/src/history/controller/build/resource/statefulset.rs
+++ b/rust/operator-binary/src/history/controller/build/resource/statefulset.rs
@@ -10,11 +10,10 @@ use stackable_operator::{
         DeepMerge,
         api::{
             apps::v1::{StatefulSet, StatefulSetSpec},
-            core::v1::{PodSecurityContext, ServiceAccount},
+            core::v1::PodSecurityContext,
         },
         apimachinery::pkg::apis::meta::v1::LabelSelector,
     },
-    kube::ResourceExt,
     product_logging::{
         framework::calculate_log_volume_size_limit,
         spec::{
@@ -84,7 +83,6 @@ pub(crate) fn build_stateful_set(
     role_group_name: &RoleGroupName,
     rg: &ValidatedHistoryRoleGroup,
     log_dir: &ResolvedLogDir,
-    serviceaccount: &ServiceAccount,
 ) -> Result<StatefulSet> {
     let resolved_product_image = &validated.resolved_product_image;
     let resource_names = validated.resource_names(role_group_name);
@@ -119,40 +117,45 @@ pub(crate) fn build_stateful_set(
         .config
         .requested_secret_lifetime
         .context(MissingSecretLifetimeSnafu)?;
-    pb.service_account_name(serviceaccount.name_unchecked())
-        .metadata(pb_metadata)
-        .image_pull_secrets_from_product_image(resolved_product_image)
-        .add_volume(
-            VolumeBuilder::new(VOLUME_MOUNT_NAME_CONFIG.as_ref())
-                .with_config_map(resource_names.role_group_config_map().to_string())
-                .build(),
-        )
-        .context(AddVolumeSnafu)?
-        .add_volume(
-            VolumeBuilder::new(VOLUME_MOUNT_NAME_LOG_CONFIG.as_ref())
-                .with_config_map(log_config_map)
-                .build(),
-        )
-        .context(AddVolumeSnafu)?
-        .add_volume(
-            VolumeBuilder::new(VOLUME_MOUNT_NAME_LOG.as_ref())
-                .with_empty_dir(
-                    None::<String>,
-                    Some(calculate_log_volume_size_limit(&[MAX_SPARK_LOG_FILES_SIZE])),
-                )
-                .build(),
-        )
-        .context(AddVolumeSnafu)?
-        .add_volumes(
-            log_dir
-                .volumes(&requested_secret_lifetime)
-                .context(CreateLogDirVolumesSpecSnafu)?,
-        )
-        .context(AddVolumeSnafu)?
-        .security_context(PodSecurityContext {
-            fs_group: Some(1000),
-            ..PodSecurityContext::default()
-        });
+    pb.service_account_name(
+        validated
+            .rbac_resource_names()
+            .service_account_name()
+            .to_string(),
+    )
+    .metadata(pb_metadata)
+    .image_pull_secrets_from_product_image(resolved_product_image)
+    .add_volume(
+        VolumeBuilder::new(VOLUME_MOUNT_NAME_CONFIG.as_ref())
+            .with_config_map(resource_names.role_group_config_map().to_string())
+            .build(),
+    )
+    .context(AddVolumeSnafu)?
+    .add_volume(
+        VolumeBuilder::new(VOLUME_MOUNT_NAME_LOG_CONFIG.as_ref())
+            .with_config_map(log_config_map)
+            .build(),
+    )
+    .context(AddVolumeSnafu)?
+    .add_volume(
+        VolumeBuilder::new(VOLUME_MOUNT_NAME_LOG.as_ref())
+            .with_empty_dir(
+                None::<String>,
+                Some(calculate_log_volume_size_limit(&[MAX_SPARK_LOG_FILES_SIZE])),
+            )
+            .build(),
+    )
+    .context(AddVolumeSnafu)?
+    .add_volumes(
+        log_dir
+            .volumes(&requested_secret_lifetime)
+            .context(CreateLogDirVolumesSpecSnafu)?,
+    )
+    .context(AddVolumeSnafu)?
+    .security_context(PodSecurityContext {
+        fs_group: Some(1000),
+        ..PodSecurityContext::default()
+    });
 
     // Base environment variables, with the already-merged (role + role group) env overrides
     // layered on top (overrides win). The base names are static and known to be valid.

--- a/rust/operator-binary/src/history/controller/build/resource/statefulset.rs
+++ b/rust/operator-binary/src/history/controller/build/resource/statefulset.rs
@@ -51,7 +51,7 @@ use crate::{
     history::{
         config::jvm::construct_history_jvm_args,
         controller::{
-            build::resource::listener::group_listener_name,
+            build::{object_meta, resource::listener::group_listener_name},
             validate::{self, ValidatedHistoryRoleGroup},
         },
     },
@@ -247,12 +247,12 @@ pub(crate) fn build_stateful_set(
     let mut pod_template = pb.build_template();
     pod_template.merge_from(rg.config.pod_overrides.clone());
 
-    let sts_metadata = validated
-        .object_meta(
-            resource_names.stateful_set_name().to_string(),
-            role_group_name,
-        )
-        .build();
+    let sts_metadata = object_meta(
+        validated,
+        resource_names.stateful_set_name().to_string(),
+        role_group_name,
+    )
+    .build();
 
     Ok(StatefulSet {
         metadata: sts_metadata,

--- a/rust/operator-binary/src/history/controller/build/resource/statefulset.rs
+++ b/rust/operator-binary/src/history/controller/build/resource/statefulset.rs
@@ -85,7 +85,7 @@ pub(crate) fn build_stateful_set(
     log_dir: &ResolvedLogDir,
 ) -> Result<StatefulSet> {
     let resolved_product_image = &validated.resolved_product_image;
-    let resource_names = validated.resource_names(role_group_name);
+    let resource_names = validated.role_group_resource_names(role_group_name);
 
     let log_config_map = if let Some(ContainerLogConfig {
         choice:
@@ -119,7 +119,7 @@ pub(crate) fn build_stateful_set(
         .context(MissingSecretLifetimeSnafu)?;
     pb.service_account_name(
         validated
-            .rbac_resource_names()
+            .cluster_resource_names()
             .service_account_name()
             .to_string(),
     )

--- a/rust/operator-binary/src/history/controller/validate.rs
+++ b/rust/operator-binary/src/history/controller/validate.rs
@@ -30,7 +30,7 @@ use stackable_operator::{
             VectorContainerLogConfig, validate_logging_configuration_for_container,
         },
         role_group_utils::ResourceNames,
-        role_utils::{JavaCommonConfig, RoleGroupConfig, with_validated_config},
+        role_utils::{self, JavaCommonConfig, RoleGroupConfig, with_validated_config},
         types::{
             kubernetes::{ConfigMapName, ListenerClassName, NamespaceName, Uid},
             operator::{
@@ -202,8 +202,17 @@ impl ValidatedSparkHistoryServer {
         RoleName::from_str(HISTORY_ROLE_NAME).expect("HISTORY_ROLE_NAME is a valid role name")
     }
 
+    /// Type-safe names for the per-cluster RBAC resources: the ServiceAccount,
+    /// its (namespaced) RoleBinding, and the operator-deployed ClusterRole it binds.
+    pub fn rbac_resource_names(&self) -> role_utils::ResourceNames {
+        role_utils::ResourceNames {
+            cluster_name: self.name.clone(),
+            product_name: product_name(),
+        }
+    }
+
     /// Type-safe names for the resources of a given role group.
-    pub(crate) fn resource_names(&self, role_group_name: &RoleGroupName) -> ResourceNames {
+    pub fn resource_names(&self, role_group_name: &RoleGroupName) -> ResourceNames {
         ResourceNames {
             cluster_name: self.name.clone(),
             role_name: Self::role_name(),
@@ -211,10 +220,25 @@ impl ValidatedSparkHistoryServer {
         }
     }
 
-    /// Recommended labels for a role-group resource, using the given product version.
-    fn recommended_labels_for(
+    /// Recommended labels for a resource of the given role.
+    pub fn recommended_labels(&self, role_group_name: &RoleGroupName) -> Labels {
+        self.recommended_labels_for(&Self::role_name(), role_group_name)
+    }
+
+    /// Recommended labels for a resource that is not tied to a concrete role
+    /// (e.g. the cluster-shared RBAC resources), using a free-form role/role-group label value.
+    pub fn recommended_labels_for(
+        &self,
+        role_name: &RoleName,
+        role_group_name: &RoleGroupName,
+    ) -> Labels {
+        self.recommended_labels_with(&self.product_version, role_name, role_group_name)
+    }
+
+    fn recommended_labels_with(
         &self,
         product_version: &ProductVersion,
+        role_name: &RoleName,
         role_group_name: &RoleGroupName,
     ) -> Labels {
         recommended_labels(
@@ -223,14 +247,9 @@ impl ValidatedSparkHistoryServer {
             product_version,
             &operator_name(),
             &controller_name(),
-            &Self::role_name(),
+            role_name,
             role_group_name,
         )
-    }
-
-    /// Recommended labels for a role-group resource.
-    pub fn recommended_labels(&self, role_group_name: &RoleGroupName) -> Labels {
-        self.recommended_labels_for(&self.product_version, role_group_name)
     }
 
     /// Selector labels matching the pods of a role group.
@@ -241,7 +260,7 @@ impl ValidatedSparkHistoryServer {
     /// Object metadata for a child resource named `name`, owned by this SparkHistoryServer and
     /// carrying the recommended labels for the given role group. Returns the builder so callers can
     /// add extra labels (e.g. Prometheus annotations) before building.
-    pub(crate) fn object_meta(
+    pub fn object_meta(
         &self,
         name: impl Into<String>,
         role_group_name: &RoleGroupName,
@@ -257,17 +276,17 @@ impl ValidatedSparkHistoryServer {
 }
 
 /// The product name (`spark-history`) as a type-safe label value.
-pub(crate) fn product_name() -> ProductName {
+pub fn product_name() -> ProductName {
     ProductName::from_str(HISTORY_APP_NAME).expect("HISTORY_APP_NAME is a valid product name")
 }
 
 /// The operator name as a type-safe label value.
-pub(crate) fn operator_name() -> OperatorName {
+pub fn operator_name() -> OperatorName {
     OperatorName::from_str(OPERATOR_NAME).expect("the operator name is a valid label value")
 }
 
 /// The controller name as a type-safe label value.
-pub(crate) fn controller_name() -> ControllerName {
+pub fn controller_name() -> ControllerName {
     ControllerName::from_str(HISTORY_CONTROLLER_NAME)
         .expect("the controller name is a valid label value")
 }

--- a/rust/operator-binary/src/history/controller/validate.rs
+++ b/rust/operator-binary/src/history/controller/validate.rs
@@ -204,7 +204,7 @@ impl ValidatedSparkHistoryServer {
 
     /// Type-safe names for the per-cluster RBAC resources: the ServiceAccount,
     /// its (namespaced) RoleBinding, and the operator-deployed ClusterRole it binds.
-    pub fn rbac_resource_names(&self) -> role_utils::ResourceNames {
+    pub fn cluster_resource_names(&self) -> role_utils::ResourceNames {
         role_utils::ResourceNames {
             cluster_name: self.name.clone(),
             product_name: product_name(),
@@ -212,7 +212,7 @@ impl ValidatedSparkHistoryServer {
     }
 
     /// Type-safe names for the resources of a given role group.
-    pub fn resource_names(&self, role_group_name: &RoleGroupName) -> ResourceNames {
+    pub fn role_group_resource_names(&self, role_group_name: &RoleGroupName) -> ResourceNames {
         ResourceNames {
             cluster_name: self.name.clone(),
             role_name: Self::role_name(),

--- a/rust/operator-binary/src/history/controller/validate.rs
+++ b/rust/operator-binary/src/history/controller/validate.rs
@@ -7,7 +7,6 @@ use std::{borrow::Cow, collections::BTreeMap, str::FromStr};
 
 use snafu::{OptionExt, ResultExt, Snafu};
 use stackable_operator::{
-    builder::meta::ObjectMetaBuilder,
     cli::OperatorEnvironmentOptions,
     commons::{
         pdb::PdbConfig,
@@ -20,10 +19,7 @@ use stackable_operator::{
     product_logging::spec::Logging,
     v2::{
         HasName, HasUid, NameIsValidLabelValue,
-        builder::{
-            meta::ownerreference_from_resource,
-            pod::container::{EnvVarName, EnvVarSet},
-        },
+        builder::pod::container::{EnvVarName, EnvVarSet},
         controller_utils::{get_cluster_name, get_namespace, get_uid},
         kvp::label::{recommended_labels, role_group_selector},
         product_logging::framework::{
@@ -255,23 +251,6 @@ impl ValidatedSparkHistoryServer {
     /// Selector labels matching the pods of a role group.
     pub fn role_group_selector(&self, role_group_name: &RoleGroupName) -> Labels {
         role_group_selector(self, &product_name(), &Self::role_name(), role_group_name)
-    }
-
-    /// Object metadata for a child resource named `name`, owned by this SparkHistoryServer and
-    /// carrying the recommended labels for the given role group. Returns the builder so callers can
-    /// add extra labels (e.g. Prometheus annotations) before building.
-    pub fn object_meta(
-        &self,
-        name: impl Into<String>,
-        role_group_name: &RoleGroupName,
-    ) -> ObjectMetaBuilder {
-        let mut builder = ObjectMetaBuilder::new();
-        builder
-            .name_and_namespace(self)
-            .name(name)
-            .ownerreference(ownerreference_from_resource(self, None, Some(true)))
-            .with_labels(self.recommended_labels(role_group_name));
-        builder
     }
 }
 

--- a/rust/operator-binary/src/history/controller/validate.rs
+++ b/rust/operator-binary/src/history/controller/validate.rs
@@ -434,3 +434,84 @@ pub fn validate(
         role_groups,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        history::controller::build::test_support::minimal_validated_cluster,
+        test_support::app_version_label,
+    };
+
+    /// Locks every value the validate step itself derives from the minimal fixture — so a
+    /// validation regression fails here, with a validate-shaped message, instead of surfacing as
+    /// a confusing build-test failure downstream.
+    ///
+    /// The merged per-role-group config is produced by the config merge machinery, whose
+    /// contracts are tested in operator-rs; only the values this module derives on top are
+    /// re-asserted here.
+    #[test]
+    fn validate_ok_derives_expected_values() {
+        let validated = minimal_validated_cluster();
+
+        assert_eq!(validated.name.to_string(), "my-history");
+        assert_eq!(validated.namespace.to_string(), "default");
+        assert_eq!(
+            validated.uid.to_string(),
+            "12345678-1234-1234-1234-123456789012"
+        );
+        assert_eq!(
+            validated.resolved_product_image.image,
+            format!(
+                "oci.example.org/sdp/spark-k8s:{}",
+                app_version_label("3.5.8")
+            )
+        );
+        assert_eq!(validated.resolved_product_image.product_version, "3.5.8");
+        assert_eq!(
+            validated.product_version.to_string(),
+            app_version_label("3.5.8")
+        );
+
+        // The custom log directory is carried through, along with the event-log settings the
+        // history server derives from it; no cleaner role group and no extra Spark config.
+        let cluster_config = &validated.cluster_config;
+        assert!(matches!(
+            &cluster_config.log_dir,
+            ResolvedLogDir::Custom(dir) if dir == "file:///stackable/spark/logs"
+        ));
+        assert_eq!(cluster_config.cleaner_rolegroup_name, None);
+        assert!(cluster_config.spark_conf.is_empty());
+        assert_eq!(
+            cluster_config.log_dir_settings,
+            BTreeMap::from([(
+                "spark.history.fs.logDirectory".to_string(),
+                "file:///stackable/spark/logs".to_string(),
+            )])
+        );
+
+        // The role config falls back to its defaults: PDBs enabled, cluster-internal listener.
+        assert!(validated.role_config.pdb.enabled);
+        assert_eq!(validated.role_config.pdb.max_unavailable, None);
+        assert_eq!(
+            validated.role_config.listener_class.to_string(),
+            "cluster-internal"
+        );
+
+        // The single `default` role group; the Vector agent is off.
+        let role_group_names: Vec<String> = validated
+            .role_groups
+            .keys()
+            .map(ToString::to_string)
+            .collect();
+        assert_eq!(role_group_names, ["default"]);
+        let role_group = validated
+            .role_groups
+            .values()
+            .next()
+            .expect("the default role group exists");
+        assert_eq!(role_group.config.replicas, Some(1));
+        assert!(!role_group.logging.enable_vector_agent);
+        assert_eq!(role_group.logging.vector_container, None);
+    }
+}

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -54,6 +54,8 @@ mod history;
 mod pod_driver_controller;
 mod product_logging;
 mod spark_k8s_controller;
+#[cfg(test)]
+pub(crate) mod test_support;
 mod webhooks;
 
 mod built_info {

--- a/rust/operator-binary/src/spark_k8s_controller/build/mod.rs
+++ b/rust/operator-binary/src/spark_k8s_controller/build/mod.rs
@@ -3,6 +3,9 @@ pub mod resource;
 
 use resource::{config_map, job};
 use snafu::{ResultExt, Snafu};
+use stackable_operator::{
+    builder::meta::ObjectMetaBuilder, v2::builder::meta::ownerreference_from_resource,
+};
 
 use crate::{
     crd::roles::SparkApplicationRole,
@@ -121,4 +124,21 @@ pub fn build(validated: &ValidatedSparkApplication) -> Result<SparkResources> {
         ],
         job,
     })
+}
+
+/// Object metadata for a child resource named `name`, owned by the SparkApplication and
+/// carrying the recommended labels for the given `role`. Returns the builder so callers can add
+/// extra labels before building.
+pub(crate) fn object_meta(
+    validated: &ValidatedSparkApplication,
+    name: impl Into<String>,
+    role: &str,
+) -> ObjectMetaBuilder {
+    let mut builder = ObjectMetaBuilder::new();
+    builder
+        .namespace(validated.namespace.clone())
+        .name(name)
+        .ownerreference(ownerreference_from_resource(validated, None, Some(true)))
+        .with_labels(validated.recommended_labels(role));
+    builder
 }

--- a/rust/operator-binary/src/spark_k8s_controller/build/resource/config_map.rs
+++ b/rust/operator-binary/src/spark_k8s_controller/build/resource/config_map.rs
@@ -20,7 +20,10 @@ use crate::{
     },
     product_logging::{self},
     spark_k8s_controller::{
-        build::pod::{self, pod_template},
+        build::{
+            object_meta,
+            pod::{self, pod_template},
+        },
         validate,
     },
 };
@@ -108,7 +111,7 @@ pub(crate) fn pod_template_config_map(
     let mut cm_builder = ConfigMapBuilder::new();
 
     cm_builder
-        .metadata(validated.object_meta(&cm_name, "pod-templates").build())
+        .metadata(object_meta(validated, &cm_name, "pod-templates").build())
         .add_data(
             POD_TEMPLATE_FILE,
             serde_yaml::to_string(&template).context(PodTemplateSerdeSnafu)?,
@@ -152,7 +155,7 @@ pub(crate) fn submit_job_config_map(
 
     let mut cm_builder = ConfigMapBuilder::new();
 
-    cm_builder.metadata(validated.object_meta(&cm_name, "spark-submit").build());
+    cm_builder.metadata(object_meta(validated, &cm_name, "spark-submit").build());
 
     cm_builder.add_data(
         SPARK_ENV_SH_FILE_NAME,

--- a/rust/operator-binary/src/spark_k8s_controller/build/resource/job.rs
+++ b/rust/operator-binary/src/spark_k8s_controller/build/resource/job.rs
@@ -17,7 +17,10 @@ use crate::{
         roles::{SparkApplicationRole, SparkContainer, SubmitConfig},
         tlscerts,
     },
-    spark_k8s_controller::{build::pod::security_context, validate},
+    spark_k8s_controller::{
+        build::{object_meta, pod::security_context},
+        validate,
+    },
 };
 
 #[derive(Snafu, Debug)]
@@ -139,9 +142,7 @@ pub(crate) fn spark_job(
     }
 
     let job = Job {
-        metadata: validated
-            .object_meta(validated.name.to_string(), "spark-job")
-            .build(),
+        metadata: object_meta(validated, validated.name.to_string(), "spark-job").build(),
         spec: Some(JobSpec {
             template: pod,
             ttl_seconds_after_finished: Some(600),

--- a/rust/operator-binary/src/spark_k8s_controller/build/resource/serviceaccount.rs
+++ b/rust/operator-binary/src/spark_k8s_controller/build/resource/serviceaccount.rs
@@ -6,7 +6,10 @@ use stackable_operator::k8s_openapi::{
     },
 };
 
-use crate::{crd::constants::*, spark_k8s_controller::validate};
+use crate::{
+    crd::constants::*,
+    spark_k8s_controller::{build::object_meta, validate},
+};
 
 /// For a given SparkApplication, we create a ServiceAccount with a RoleBinding to the ClusterRole
 /// that allows the driver to create pods etc.
@@ -17,12 +20,12 @@ pub(crate) fn build_spark_role_serviceaccount(
 ) -> (ServiceAccount, RoleBinding) {
     let sa_name = validated.name.to_string();
     let sa = ServiceAccount {
-        metadata: validated.object_meta(&sa_name, "service-account").build(),
+        metadata: object_meta(validated, &sa_name, "service-account").build(),
         ..ServiceAccount::default()
     };
     let binding_name = &sa_name;
     let binding = RoleBinding {
-        metadata: validated.object_meta(binding_name, "role-binding").build(),
+        metadata: object_meta(validated, binding_name, "role-binding").build(),
         role_ref: RoleRef {
             api_group: Some(ClusterRole::GROUP.to_string()),
             kind: ClusterRole::KIND.to_string(),

--- a/rust/operator-binary/src/spark_k8s_controller/validate.rs
+++ b/rust/operator-binary/src/spark_k8s_controller/validate.rs
@@ -7,7 +7,6 @@ use std::{borrow::Cow, str::FromStr};
 
 use snafu::{ResultExt, Snafu};
 use stackable_operator::{
-    builder::meta::ObjectMetaBuilder,
     cli::OperatorEnvironmentOptions,
     commons::{
         product_image_selection::{self, ResolvedProductImage},
@@ -19,7 +18,6 @@ use stackable_operator::{
     kvp::Labels,
     v2::{
         HasName, HasUid, NameIsValidLabelValue,
-        builder::meta::ownerreference_from_resource,
         controller_utils::{get_cluster_name, get_namespace, get_uid},
         kvp::label::recommended_labels,
         types::{
@@ -169,19 +167,6 @@ impl ValidatedSparkApplication {
             &role_name,
             &role_group,
         )
-    }
-
-    /// Object metadata for a child resource named `name`, owned by this SparkApplication and
-    /// carrying the recommended labels for the given `role`. Returns the builder so callers can add
-    /// extra labels before building.
-    pub(crate) fn object_meta(&self, name: impl Into<String>, role: &str) -> ObjectMetaBuilder {
-        let mut builder = ObjectMetaBuilder::new();
-        builder
-            .namespace(self.namespace.clone())
-            .name(name)
-            .ownerreference(ownerreference_from_resource(self, None, Some(true)))
-            .with_labels(self.recommended_labels(role));
-        builder
     }
 }
 

--- a/rust/operator-binary/src/spark_k8s_controller/validate.rs
+++ b/rust/operator-binary/src/spark_k8s_controller/validate.rs
@@ -241,3 +241,76 @@ fn reject_tls_no_verification(conn: &s3::v1alpha1::ConnectionSpec, context: &str
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use stackable_operator::cli::OperatorEnvironmentOptions;
+
+    use super::*;
+    use crate::test_support::app_version_label;
+
+    /// Locks every value the validate step itself derives from the minimal fixture. The raw
+    /// `SparkApplication` is deliberately retained on the validated type (see the field docs),
+    /// so only the resolved identity, image and cluster config are derived here.
+    #[test]
+    fn validate_ok_derives_expected_values() {
+        let yaml = indoc! {r#"
+            apiVersion: spark.stackable.tech/v1alpha1
+            kind: SparkApplication
+            metadata:
+              name: spark-example
+              namespace: default
+              uid: 12345678-1234-1234-1234-123456789012
+            spec:
+              mode: cluster
+              mainApplicationFile: test.py
+              sparkImage:
+                productVersion: 1.2.3
+        "#};
+        let deserializer = serde_yaml::Deserializer::from_str(yaml);
+        let spark_application: v1alpha1::SparkApplication =
+            serde_yaml::with::singleton_map_recursive::deserialize(deserializer)
+                .expect("invalid test SparkApplication YAML");
+
+        let validated = validate(
+            DereferencedSparkApplication {
+                spark_application,
+                resolved_template_refs: Vec::new(),
+                s3_connection: None,
+                log_dir: None,
+            },
+            &OperatorEnvironmentOptions {
+                operator_namespace: "stackable-operators".to_string(),
+                operator_service_name: "spark-k8s-operator".to_string(),
+                image_repository: "oci.example.org/sdp".to_string(),
+            },
+        )
+        .expect("the minimal fixture validates");
+
+        assert_eq!(validated.name.to_string(), "spark-example");
+        assert_eq!(validated.namespace.to_string(), "default");
+        assert_eq!(
+            validated.uid.to_string(),
+            "12345678-1234-1234-1234-123456789012"
+        );
+        assert_eq!(
+            validated.resolved_product_image.image,
+            format!(
+                "oci.example.org/sdp/spark-k8s:{}",
+                app_version_label("1.2.3")
+            )
+        );
+        assert_eq!(validated.resolved_product_image.product_version, "1.2.3");
+
+        // The minimal fixture references no templates, no S3 connection and no log directory,
+        // and the raw spec is retained for the pod builders.
+        assert!(validated.cluster_config.resolved_template_refs.is_empty());
+        assert!(validated.cluster_config.s3_connection.is_none());
+        assert!(validated.cluster_config.log_dir.is_none());
+        assert_eq!(
+            validated.spark_application.metadata.name.as_deref(),
+            Some("spark-example")
+        );
+    }
+}

--- a/rust/operator-binary/src/test_support.rs
+++ b/rust/operator-binary/src/test_support.rs
@@ -1,0 +1,13 @@
+//! Shared helpers for the crate's tests.
+
+/// The expected `app.kubernetes.io/version` label value for the given product version.
+///
+/// The `-stackable` suffix carries the operator's own version, which is `0.0.0-dev` on main
+/// but rewritten by the release process — so tests must derive it rather than hardcode it,
+/// or they fail on release branches.
+pub fn app_version_label(product_version: &str) -> String {
+    format!(
+        "{product_version}-stackable{}",
+        crate::built_info::PKG_VERSION
+    )
+}


### PR DESCRIPTION
## Description

Part of: https://github.com/stackabletech/issues/issues/869

- Add missing RBAC labels (service account, role binding)
- use infallible rbac functions (requires https://github.com/stackabletech/operator-rs/pull/1251)
- some label cleanup
- consistent role_name function

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [x] Code contains useful comments
- [x] (Integration-)Test cases added
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
