### PR TITLE
cherry-pick:  refactor: snapshot tests to be Spark image agnostic (#733)

### DIFF
--- a/tests/templates/kuttl/smoke/43-assert.yaml.j2
+++ b/tests/templates/kuttl/smoke/43-assert.yaml.j2
@@ -1,278 +1,266 @@
 ---
-# Snapshot the full `.data` of each operator-managed ConfigMap.
-# Any code change that alters rendered config values will fail these diffs.
+# Snapshot the `.data` of the operator-managed ConfigMap as a plain Kubernetes
+# object and let kuttl compare it. Any code change that alters a rendered
+# config value fails this assert.
 #
-# Runs as its own step (after 40/41/42) so kuttl does not re-evaluate the heavy
-# heredoc on every 1-second readiness retry of the install step. By this point
-# the cluster is in steady state, so each script runs once.
+# Notes:
 #
-# The heredoc is quoted (`<<'YAMLEOF'`) so shell substitution is disabled and
-# any property-style escapes survive verbatim. Only `__NAMESPACE__` is
-# substituted afterwards via `sed`, because kuttl tests run in a randomized
-# namespace per invocation. Both sides are normalized to canonical JSON via
-# `yq -o=json` before comparison.
+#  * kuttl subset-matches maps, so a key the operator newly adds to `.data` does
+#    not fail this assert. Add it below to cover it.
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 timeout: 60
-commands:
-  - script: |
-      expected=$(cat <<'YAMLEOF' | sed "s|__NAMESPACE__|$NAMESPACE|g" | yq -o=json
-      security.properties: "networkaddress.cache.negative.ttl=0\nnetworkaddress.cache.ttl=30\n"
-      spark-defaults.conf: |
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spark-history-node-default
+data:
+  security.properties: |
+    networkaddress.cache.negative.ttl=0
+    networkaddress.cache.ttl=30
+  spark-defaults.conf: |
 {% if test_scenario['values']['s3-use-tls'] == 'true' %}
-        spark.hadoop.fs.s3a.endpoint=https\://eventlog-minio\:9000/
+    spark.hadoop.fs.s3a.endpoint=https\://eventlog-minio\:9000/
 {% else %}
-        spark.hadoop.fs.s3a.endpoint=http\://eventlog-minio\:9000/
+    spark.hadoop.fs.s3a.endpoint=http\://eventlog-minio\:9000/
 {% endif %}
-        spark.hadoop.fs.s3a.endpoint.region=us-east-1
-        spark.hadoop.fs.s3a.path.style.access=true
-        spark.history.fs.cleaner.enabled=true
-        spark.history.fs.logDirectory=s3a\://spark-logs/eventlogs/
-      spark-env.sh: ""
+    spark.hadoop.fs.s3a.endpoint.region=us-east-1
+    spark.hadoop.fs.s3a.path.style.access=true
+    spark.history.fs.cleaner.enabled=true
+    spark.history.fs.logDirectory=s3a\://spark-logs/eventlogs/
+  spark-env.sh: ""
 {% if lookup('env', 'VECTOR_AGGREGATOR') %}
-      vector.yaml: |
-        ---
-        data_dir: ${DATA_DIR}
+  vector.yaml: |
+    ---
+    data_dir: ${DATA_DIR}
 
-        log_schema:
-          host_key: pod
+    log_schema:
+      host_key: pod
 
-        sources:
-          # Reads the internal Vector logs
-          vector:
-            type: internal_logs
+    sources:
+      # Reads the internal Vector logs
+      vector:
+        type: internal_logs
 
-          files_stdout:
-            type: file
-            include:
-              - ${LOG_DIR}/*/*.stdout.log
+      files_stdout:
+        type: file
+        include:
+          - ${LOG_DIR}/*/*.stdout.log
 
-          files_stderr:
-            type: file
-            include:
-              - ${LOG_DIR}/*/*.stderr.log
+      files_stderr:
+        type: file
+        include:
+          - ${LOG_DIR}/*/*.stderr.log
 
-          files_log4j2:
-            type: file
-            include:
-              - ${LOG_DIR}/*/*.log4j2.xml
-            line_delimiter: "\r\n"
+      files_log4j2:
+        type: file
+        include:
+          - ${LOG_DIR}/*/*.log4j2.xml
+        line_delimiter: "\r\n"
 
-        transforms:
-          processed_files_stdout:
-            inputs:
-              - files_stdout
-            type: remap
-            source: |
-              .logger = "ROOT"
-              .level = "INFO"
+    transforms:
+      processed_files_stdout:
+        inputs:
+          - files_stdout
+        type: remap
+        source: |
+          .logger = "ROOT"
+          .level = "INFO"
 
-          processed_files_stderr:
-            inputs:
-              - files_stderr
-            type: remap
-            source: |
-              .logger = "ROOT"
-              .level = "ERROR"
+      processed_files_stderr:
+        inputs:
+          - files_stderr
+        type: remap
+        source: |
+          .logger = "ROOT"
+          .level = "ERROR"
 
-          processed_files_log4j2:
-            inputs:
-              - files_log4j2
-            type: remap
-            source: |
-              raw_message = string!(.message)
+      processed_files_log4j2:
+        inputs:
+          - files_log4j2
+        type: remap
+        source: |
+          raw_message = string!(.message)
 
-              .timestamp = now()
-              .logger = ""
-              .level = "INFO"
-              .message = ""
-              .errors = []
+          .timestamp = now()
+          .logger = ""
+          .level = "INFO"
+          .message = ""
+          .errors = []
 
-              event = {}
-              parsed_event, err = parse_xml(raw_message)
-              if err != null {
-                error = "XML not parsable: " + err
-                .errors = push(.errors, error)
-                log(error, level: "warn")
-                .message = raw_message
-              } else {
-                if !is_object(parsed_event.Event) {
-                  error = "Parsed event contains no \"Event\" tag."
-                  .errors = push(.errors, error)
-                  log(error, level: "warn")
-                  .message = raw_message
-                } else {
-                  event = object!(parsed_event.Event)
+          event = {}
+          parsed_event, err = parse_xml(raw_message)
+          if err != null {
+            error = "XML not parsable: " + err
+            .errors = push(.errors, error)
+            log(error, level: "warn")
+            .message = raw_message
+          } else {
+            if !is_object(parsed_event.Event) {
+              error = "Parsed event contains no \"Event\" tag."
+              .errors = push(.errors, error)
+              log(error, level: "warn")
+              .message = raw_message
+            } else {
+              event = object!(parsed_event.Event)
 
-                  tag_instant_valid = false
-                  instant, err = object(event.Instant)
+              tag_instant_valid = false
+              instant, err = object(event.Instant)
+              if err == null {
+                epoch_nanoseconds, err = to_int(instant.@epochSecond) * 1_000_000_000 + to_int(instant.@nanoOfSecond)
+                if err == null && epoch_nanoseconds != 0 {
+                  converted_timestamp, err = from_unix_timestamp(epoch_nanoseconds, "nanoseconds")
                   if err == null {
-                    epoch_nanoseconds, err = to_int(instant.@epochSecond) * 1_000_000_000 + to_int(instant.@nanoOfSecond)
-                    if err == null && epoch_nanoseconds != 0 {
-                      converted_timestamp, err = from_unix_timestamp(epoch_nanoseconds, "nanoseconds")
-                      if err == null {
-                        .timestamp = converted_timestamp
-                        tag_instant_valid = true
-                      } else {
-                        .errors = push(.errors, "Instant invalid, trying property timeMillis instead: " + err)
-                      }
-                    } else {
-                      .errors = push(.errors, "Instant invalid, trying property timeMillis instead: " + err)
-                    }
-                  }
-                  if !tag_instant_valid {
-                    epoch_milliseconds, err = to_int(event.@timeMillis)
-                    if err == null && epoch_milliseconds != 0 {
-                      converted_timestamp, err = from_unix_timestamp(epoch_milliseconds, "milliseconds")
-                      if err == null {
-                        .timestamp = converted_timestamp
-                      } else {
-                        .errors = push(.errors, "timeMillis not parsable, using current time instead: " + err)
-                      }
-                    } else {
-                      .errors = push(.errors, "timeMillis not parsable, using current time instead: " + err)
-                    }
-                  }
-
-                  .logger, err = string(event.@loggerName)
-                  if err != null || is_empty(.logger) {
-                    .errors = push(.errors, "Logger not found.")
-                  }
-
-                  level, err = string(event.@level)
-                  if err != null {
-                    .errors = push(.errors, "Level not found, using \"" + .level + "\" instead.")
-                  } else if !includes(["TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"], level) {
-                    .errors = push(.errors, "Level \"" + level + "\" unknown, using \"" + .level + "\" instead.")
+                    .timestamp = converted_timestamp
+                    tag_instant_valid = true
                   } else {
-                    .level = level
+                    .errors = push(.errors, "Instant invalid, trying property timeMillis instead: " + err)
                   }
-
-                  exception = null
-                  thrown = event.Thrown
-                  if is_object(thrown) {
-                    exception = "Exception"
-                    thread, err = string(event.@thread)
-                    if err == null && !is_empty(thread) {
-                      exception = exception + " in thread \"" + thread + "\""
-                    }
-                    thrown_name, err = string(thrown.@name)
-                    if err == null && !is_empty(exception) {
-                      exception = exception + " " + thrown_name
-                    }
-                    message = string(thrown.@localizedMessage) ??
-                      string(thrown.@message) ??
-                      ""
-                    if !is_empty(message) {
-                      exception = exception + ": " + message
-                    }
-                    stacktrace_items = array(thrown.ExtendedStackTrace.ExtendedStackTraceItem) ?? []
-                    stacktrace = ""
-                    for_each(stacktrace_items) -> |_index, value| {
-                      stacktrace = stacktrace + "        "
-                      class = string(value.@class) ?? ""
-                      method = string(value.@method) ?? ""
-                      if !is_empty(class) && !is_empty(method) {
-                        stacktrace = stacktrace + "at " + class + "." + method
-                      }
-                      file = string(value.@file) ?? ""
-                      line = string(value.@line) ?? ""
-                      if !is_empty(file) && !is_empty(line) {
-                        stacktrace = stacktrace + "(" + file + ":" + line + ")"
-                      }
-                      exact = to_bool(value.@exact) ?? false
-                      location = string(value.@location) ?? ""
-                      version = string(value.@version) ?? ""
-                      if !is_empty(location) && !is_empty(version) {
-                        stacktrace = stacktrace + " "
-                        if !exact {
-                          stacktrace = stacktrace + "~"
-                        }
-                        stacktrace = stacktrace + "[" + location + ":" + version + "]"
-                      }
-                      stacktrace = stacktrace + "\n"
-                    }
-                    if stacktrace != "" {
-                      exception = exception + "\n" + stacktrace
-                    }
+                } else {
+                  .errors = push(.errors, "Instant invalid, trying property timeMillis instead: " + err)
+                }
+              }
+              if !tag_instant_valid {
+                epoch_milliseconds, err = to_int(event.@timeMillis)
+                if err == null && epoch_milliseconds != 0 {
+                  converted_timestamp, err = from_unix_timestamp(epoch_milliseconds, "milliseconds")
+                  if err == null {
+                    .timestamp = converted_timestamp
+                  } else {
+                    .errors = push(.errors, "timeMillis not parsable, using current time instead: " + err)
                   }
-
-                  message, err = string(event.Message)
-                  if err != null || is_empty(message) {
-                    message = null
-                    .errors = push(.errors, "Message not found.")
-                  }
-                  .message = join!(compact([message, exception]), "\n")
+                } else {
+                  .errors = push(.errors, "timeMillis not parsable, using current time instead: " + err)
                 }
               }
 
-          # Extends the processed files with the fields "container" and "file"
-          extended_logs_files:
-            inputs:
-              - processed_files_*
-            type: remap
-            source: |
-              del(.source_type)
-              if .errors == [] {
-                del(.errors)
+              .logger, err = string(event.@loggerName)
+              if err != null || is_empty(.logger) {
+                .errors = push(.errors, "Logger not found.")
               }
-              . |= parse_regex!(.file, r'^${LOG_DIR}/(?P<container>.*?)/(?P<file>.*?)$')
 
-          # Filters the logs of the Vector agent according to the defined log level
-          filtered_logs_vector:
-            inputs:
-              - vector
-            type: filter
-            condition: >
-              (.metadata.level == "TRACE" && "${VECTOR_FILE_LOG_LEVEL}" == "trace") ||
-              (.metadata.level == "DEBUG" && includes(["trace", "debug"], "${VECTOR_FILE_LOG_LEVEL}")) ||
-              (.metadata.level == "INFO" && includes(["trace", "debug", "info"], "${VECTOR_FILE_LOG_LEVEL}")) ||
-              (.metadata.level == "WARN" && includes(["trace", "debug", "info", "warn"], "${VECTOR_FILE_LOG_LEVEL}")) ||
-              (.metadata.level == "ERROR" && includes(["trace", "debug", "info", "warn", "error"], "${VECTOR_FILE_LOG_LEVEL}"))
+              level, err = string(event.@level)
+              if err != null {
+                .errors = push(.errors, "Level not found, using \"" + .level + "\" instead.")
+              } else if !includes(["TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"], level) {
+                .errors = push(.errors, "Level \"" + level + "\" unknown, using \"" + .level + "\" instead.")
+              } else {
+                .level = level
+              }
 
-          # Aligns the logs of the Vector agent with the common format
-          extended_logs_vector:
-            inputs:
-              - filtered_logs_vector
-            type: remap
-            source: |
-              .container = "vector"
-              .level = .metadata.level
-              .logger = .metadata.module_path
-              if exists(.file) { .processed_file = del(.file) }
-              del(.metadata)
-              del(.pid)
-              del(.source_type)
+              exception = null
+              thrown = event.Thrown
+              if is_object(thrown) {
+                exception = "Exception"
+                thread, err = string(event.@thread)
+                if err == null && !is_empty(thread) {
+                  exception = exception + " in thread \"" + thread + "\""
+                }
+                thrown_name, err = string(thrown.@name)
+                if err == null && !is_empty(exception) {
+                  exception = exception + " " + thrown_name
+                }
+                message = string(thrown.@localizedMessage) ??
+                  string(thrown.@message) ??
+                  ""
+                if !is_empty(message) {
+                  exception = exception + ": " + message
+                }
+                stacktrace_items = array(thrown.ExtendedStackTrace.ExtendedStackTraceItem) ?? []
+                stacktrace = ""
+                for_each(stacktrace_items) -> |_index, value| {
+                  stacktrace = stacktrace + "        "
+                  class = string(value.@class) ?? ""
+                  method = string(value.@method) ?? ""
+                  if !is_empty(class) && !is_empty(method) {
+                    stacktrace = stacktrace + "at " + class + "." + method
+                  }
+                  file = string(value.@file) ?? ""
+                  line = string(value.@line) ?? ""
+                  if !is_empty(file) && !is_empty(line) {
+                    stacktrace = stacktrace + "(" + file + ":" + line + ")"
+                  }
+                  exact = to_bool(value.@exact) ?? false
+                  location = string(value.@location) ?? ""
+                  version = string(value.@version) ?? ""
+                  if !is_empty(location) && !is_empty(version) {
+                    stacktrace = stacktrace + " "
+                    if !exact {
+                      stacktrace = stacktrace + "~"
+                    }
+                    stacktrace = stacktrace + "[" + location + ":" + version + "]"
+                  }
+                  stacktrace = stacktrace + "\n"
+                }
+                if stacktrace != "" {
+                  exception = exception + "\n" + stacktrace
+                }
+              }
 
-          # Add the fields "namespace", "cluster", "role" and "roleGroup" to all logs
-          extended_logs:
-            inputs:
-              - extended_logs_*
-            type: remap
-            source: |
-              .namespace = "${NAMESPACE}"
-              .cluster = "${CLUSTER_NAME}"
-              .role = "${ROLE_NAME}"
-              .roleGroup = "${ROLE_GROUP_NAME}"
+              message, err = string(event.Message)
+              if err != null || is_empty(message) {
+                message = null
+                .errors = push(.errors, "Message not found.")
+              }
+              .message = join!(compact([message, exception]), "\n")
+            }
+          }
 
-        sinks:
-          # Forward the logs to the Vector aggregator
-          aggregator:
-            inputs:
-              - extended_logs
-            type: vector
-            address: ${VECTOR_AGGREGATOR_ADDRESS}
+      # Extends the processed files with the fields "container" and "file"
+      extended_logs_files:
+        inputs:
+          - processed_files_*
+        type: remap
+        source: |
+          del(.source_type)
+          if .errors == [] {
+            del(.errors)
+          }
+          . |= parse_regex!(.file, r'^${LOG_DIR}/(?P<container>.*?)/(?P<file>.*?)$')
+
+      # Filters the logs of the Vector agent according to the defined log level
+      filtered_logs_vector:
+        inputs:
+          - vector
+        type: filter
+        condition: >
+          (.metadata.level == "TRACE" && "${VECTOR_FILE_LOG_LEVEL}" == "trace") ||
+          (.metadata.level == "DEBUG" && includes(["trace", "debug"], "${VECTOR_FILE_LOG_LEVEL}")) ||
+          (.metadata.level == "INFO" && includes(["trace", "debug", "info"], "${VECTOR_FILE_LOG_LEVEL}")) ||
+          (.metadata.level == "WARN" && includes(["trace", "debug", "info", "warn"], "${VECTOR_FILE_LOG_LEVEL}")) ||
+          (.metadata.level == "ERROR" && includes(["trace", "debug", "info", "warn", "error"], "${VECTOR_FILE_LOG_LEVEL}"))
+
+      # Aligns the logs of the Vector agent with the common format
+      extended_logs_vector:
+        inputs:
+          - filtered_logs_vector
+        type: remap
+        source: |
+          .container = "vector"
+          .level = .metadata.level
+          .logger = .metadata.module_path
+          if exists(.file) { .processed_file = del(.file) }
+          del(.metadata)
+          del(.pid)
+          del(.source_type)
+
+      # Add the fields "namespace", "cluster", "role" and "roleGroup" to all logs
+      extended_logs:
+        inputs:
+          - extended_logs_*
+        type: remap
+        source: |
+          .namespace = "${NAMESPACE}"
+          .cluster = "${CLUSTER_NAME}"
+          .role = "${ROLE_NAME}"
+          .roleGroup = "${ROLE_GROUP_NAME}"
+
+    sinks:
+      # Forward the logs to the Vector aggregator
+      aggregator:
+        inputs:
+          - extended_logs
+        type: vector
+        address: ${VECTOR_AGGREGATOR_ADDRESS}
 {% endif %}
-      YAMLEOF
-      )
-      actual=$(kubectl -n $NAMESPACE get cm spark-history-node-default -o yaml | yq -o=json '.data')
-      expected_file=$(mktemp) && actual_file=$(mktemp)
-      printf '%s\n' "$expected" > "$expected_file"
-      printf '%s\n' "$actual" > "$actual_file"
-      if ! diff_out=$(diff -u "$expected_file" "$actual_file"); then
-        echo "ERROR: ConfigMap spark-history-node-default data drifted from snapshot."
-        printf '%s\n' "$diff_out"
-        rm -f "$expected_file" "$actual_file"
-        exit 1
-      fi
-      rm -f "$expected_file" "$actual_file"

--- a/tests/templates/kuttl/smoke/53-assert.yaml.j2
+++ b/tests/templates/kuttl/smoke/53-assert.yaml.j2
@@ -1,1013 +1,568 @@
 ---
-# Snapshot the full `.data` of each SparkApplication-owned ConfigMap.
-# Any code change that alters rendered config values will fail these diffs.
+# Snapshot the `.data` of the SparkApplication-owned ConfigMaps as plain
+# Kubernetes objects and let kuttl compare them. Any code change that alters a
+# rendered config value fails this assert.
 #
-# Runs as its own step (after 50/51/52) so kuttl does not re-evaluate the heavy
-# heredoc on every 1-second readiness retry of the install step. By this point
-# the cluster is in steady state, so each script runs once.
+# Notes:
 #
-# The heredoc is quoted (`<<'YAMLEOF'`) so shell substitution is disabled and
-# any property-style escapes survive verbatim. Only `__NAMESPACE__` is
-# substituted afterwards via `sed`, because kuttl tests run in a randomized
-# namespace per invocation. Both sides are normalized to canonical JSON via
-# `yq -o=json` before comparison.
+#  * kuttl subset-matches maps, so a key the operator newly adds to `.data` does
+#    not fail this assert. Add it below to cover it.
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 timeout: 60
-commands:
-  - script: |
-      expected=$(cat <<'YAMLEOF' | sed "s|__NAMESPACE__|$NAMESPACE|g" | yq -o=json
-      log4j2.properties: |-
-        appenders = FILE, CONSOLE
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spark-pi-s3-1-driver-pod-template
+data:
+  log4j2.properties: |-
+    appenders = FILE, CONSOLE
 
-        appender.CONSOLE.type = Console
-        appender.CONSOLE.name = CONSOLE
-        appender.CONSOLE.target = SYSTEM_ERR
-        appender.CONSOLE.layout.type = PatternLayout
-        appender.CONSOLE.layout.pattern = %d{ISO8601} %p [%t] %c - %m%n
-        appender.CONSOLE.filter.threshold.type = ThresholdFilter
-        appender.CONSOLE.filter.threshold.level = INFO
+    appender.CONSOLE.type = Console
+    appender.CONSOLE.name = CONSOLE
+    appender.CONSOLE.target = SYSTEM_ERR
+    appender.CONSOLE.layout.type = PatternLayout
+    appender.CONSOLE.layout.pattern = %d{ISO8601} %p [%t] %c - %m%n
+    appender.CONSOLE.filter.threshold.type = ThresholdFilter
+    appender.CONSOLE.filter.threshold.level = INFO
 
-        appender.FILE.type = RollingFile
-        appender.FILE.name = FILE
-        appender.FILE.fileName = /stackable/log/spark/spark.log4j2.xml
-        appender.FILE.filePattern = /stackable/log/spark/spark.log4j2.xml.%i
-        appender.FILE.layout.type = XMLLayout
-        appender.FILE.policies.type = Policies
-        appender.FILE.policies.size.type = SizeBasedTriggeringPolicy
-        appender.FILE.policies.size.size = 5MB
-        appender.FILE.strategy.type = DefaultRolloverStrategy
-        appender.FILE.strategy.max = 1
-        appender.FILE.filter.threshold.type = ThresholdFilter
-        appender.FILE.filter.threshold.level = INFO
+    appender.FILE.type = RollingFile
+    appender.FILE.name = FILE
+    appender.FILE.fileName = /stackable/log/spark/spark.log4j2.xml
+    appender.FILE.filePattern = /stackable/log/spark/spark.log4j2.xml.%i
+    appender.FILE.layout.type = XMLLayout
+    appender.FILE.policies.type = Policies
+    appender.FILE.policies.size.type = SizeBasedTriggeringPolicy
+    appender.FILE.policies.size.size = 5MB
+    appender.FILE.strategy.type = DefaultRolloverStrategy
+    appender.FILE.strategy.max = 1
+    appender.FILE.filter.threshold.type = ThresholdFilter
+    appender.FILE.filter.threshold.level = INFO
 
 
-        rootLogger.level=INFO
-        rootLogger.appenderRefs = CONSOLE, FILE
-        rootLogger.appenderRef.CONSOLE.ref = CONSOLE
-        rootLogger.appenderRef.FILE.ref = FILE
-      security.properties: |
-        networkaddress.cache.negative.ttl=0
-        networkaddress.cache.ttl=30
-      spark-env.sh: ""
-      template.yaml: |
-        metadata:
-          labels:
-            app.kubernetes.io/component: spark
-            app.kubernetes.io/instance: spark-pi-s3-1
-            app.kubernetes.io/managed-by: spark.stackable.tech_sparkapplication
-            app.kubernetes.io/name: spark-k8s
-            app.kubernetes.io/role-group: sparkapplication
-            app.kubernetes.io/version: {{ test_scenario['values']['spark'].split(',')[0] }}-stackable0.0.0-dev
-            prometheus.io/scrape: 'true'
-            stackable.tech/vendor: Stackable
-          name: spark
-        spec:
-          affinity: {}
-          containers:
-          - env:
-            - name: CONTAINERDEBUG_LOG_DIRECTORY
-              value: /stackable/log/containerdebug
-{% if test_scenario['values']['s3-use-tls'] == 'true' %}
-            - name: STACKABLE_TLS_STORE_PASSWORD
-              value: changeit
-{% endif %}
-            - name: _STACKABLE_PRE_HOOK
-              value: containerdebug --output=/stackable/log/containerdebug-state.json --loop &
+    rootLogger.level=INFO
+    rootLogger.appenderRefs = CONSOLE, FILE
+    rootLogger.appenderRef.CONSOLE.ref = CONSOLE
+    rootLogger.appenderRef.FILE.ref = FILE
+  security.properties: |
+    networkaddress.cache.negative.ttl=0
+    networkaddress.cache.ttl=30
+  spark-env.sh: ""
 {% if lookup('env', 'VECTOR_AGGREGATOR') %}
-            - name: _STACKABLE_POST_HOOK
-              value: sleep 10; mkdir -p /stackable/log/_vector && touch /stackable/log/_vector/shutdown
-{% endif %}
-            image: oci.stackable.tech/sdp/spark-k8s:{{ test_scenario['values']['spark'].split(',')[0] }}-stackable0.0.0-dev
-            imagePullPolicy: IfNotPresent
-            name: spark
-            resources:
-              limits:
-                cpu: '1'
-                memory: 1Gi
-              requests:
-                cpu: 250m
-                memory: 1Gi
-            volumeMounts:
-            - mountPath: /stackable/secrets/s3-credentials-class
-              name: s3-credentials-class
-            - mountPath: /stackable/secrets/history-credentials-class
-              name: history-credentials-class
-            - mountPath: /stackable/log_config
-              name: log-config
-            - mountPath: /stackable/log
-              name: log
-{% if test_scenario['values']['s3-use-tls'] == 'true' %}
-            - mountPath: /stackable/truststore
-              name: stackable-truststore
-            - mountPath: /stackable/mount_server_tls/minio-tls-eventlog
-              name: minio-tls-eventlog
-{% endif %}
-{% if lookup('env', 'VECTOR_AGGREGATOR') %}
-          - args:
-            - |-
-              mkdir --parents /stackable/log/_vector-state
-              # Vector will ignore SIGTERM (as PID != 1) and must be shut down by writing a shutdown trigger file
-              vector & vector_pid=$!
-              if [ ! -f "/stackable/log/_vector/shutdown" ]; then
-              mkdir -p /stackable/log/_vector
-              inotifywait -qq --event create /stackable/log/_vector;
-              fi
-              sleep 1
-              kill $vector_pid
-            command:
-            - /bin/bash
-            - -x
-            - -euo
-            - pipefail
-            - -c
-            env:
-            - name: CLUSTER_NAME
-              value: spark-pi-s3-1
-            - name: DATA_DIR
-              value: /stackable/log/_vector-state
-            - name: LOG_DIR
-              value: /stackable/log
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: ROLE_GROUP_NAME
-              value: default
-            - name: ROLE_NAME
-              value: driver
-            - name: VECTOR_AGGREGATOR_ADDRESS
-              valueFrom:
-                configMapKeyRef:
-                  key: ADDRESS
-                  name: vector-aggregator-discovery
-            - name: VECTOR_CONFIG_YAML
-              value: /stackable/config/vector.yaml
-            - name: VECTOR_FILE_LOG_LEVEL
-              value: info
-            - name: VECTOR_LOG
-              value: info
-            image: oci.stackable.tech/sdp/spark-k8s:{{ test_scenario['values']['spark'].split(',')[0] }}-stackable0.0.0-dev
-            imagePullPolicy: IfNotPresent
-            name: vector
-            resources:
-              limits:
-                cpu: 500m
-                memory: 128Mi
-              requests:
-                cpu: 250m
-                memory: 128Mi
-            volumeMounts:
-            - mountPath: /stackable/config/vector.yaml
-              name: config
-              readOnly: true
-              subPath: vector.yaml
-            - mountPath: /stackable/log
-              name: log
-{% endif %}
-          enableServiceLinks: false
-{% if test_scenario['values']['s3-use-tls'] == 'true' %}
-          initContainers:
-          - args:
-            - |-
-              cert-tools generate-pkcs12-truststore --pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem --out /stackable/truststore/truststore.p12 --out-password changeit
-              cert-tools generate-pkcs12-truststore --pkcs12 /stackable/truststore/truststore.p12:changeit --pkcs12 /stackable/mount_server_tls/minio-tls-eventlog/truststore.p12 --out /stackable/truststore/truststore.p12 --out-password changeit
-            command:
-            - /bin/bash
-            - -x
-            - -euo
-            - pipefail
-            - -c
-            image: oci.stackable.tech/sdp/spark-k8s:{{ test_scenario['values']['spark'].split(',')[0] }}-stackable0.0.0-dev
-            name: tls
-            resources:
-              limits:
-                cpu: 1000m
-                memory: 1024Mi
-              requests:
-                cpu: 250m
-                memory: 1024Mi
-            volumeMounts:
-            - mountPath: /stackable/mount_server_tls/minio-tls-eventlog
-              name: minio-tls-eventlog
-            - mountPath: /stackable/truststore
-              name: stackable-truststore
-{% endif %}
-          securityContext:
-            fsGroup: 1000
-          serviceAccountName: spark-pi-s3-1
-          volumes:
-          - ephemeral:
-              volumeClaimTemplate:
-                metadata:
-                  annotations:
-                    secrets.stackable.tech/class: history-credentials-class
-                    secrets.stackable.tech/provision-parts: public-private
-                spec:
-                  accessModes:
-                  - ReadWriteOnce
-                  resources:
-                    requests:
-                      storage: '1'
-                  storageClassName: secrets.stackable.tech
-            name: history-credentials-class
-          - emptyDir:
-              sizeLimit: 39Mi
-            name: log
-          - configMap:
-              name: spark-pi-s3-1-driver-pod-template
-            name: log-config
-{% if test_scenario['values']['s3-use-tls'] == 'true' %}
-          - ephemeral:
-              volumeClaimTemplate:
-                metadata:
-                  annotations:
-                    secrets.stackable.tech/backend.autotls.cert.lifetime: 1d
-                    secrets.stackable.tech/class: minio-tls-eventlog
-                    secrets.stackable.tech/format: tls-pkcs12
-                    secrets.stackable.tech/provision-parts: public
-                spec:
-                  accessModes:
-                  - ReadWriteOnce
-                  resources:
-                    requests:
-                      storage: '1'
-                  storageClassName: secrets.stackable.tech
-            name: minio-tls-eventlog
-{% endif %}
-          - ephemeral:
-              volumeClaimTemplate:
-                metadata:
-                  annotations:
-                    secrets.stackable.tech/class: s3-credentials-class
-                    secrets.stackable.tech/provision-parts: public-private
-                spec:
-                  accessModes:
-                  - ReadWriteOnce
-                  resources:
-                    requests:
-                      storage: '1'
-                  storageClassName: secrets.stackable.tech
-            name: s3-credentials-class
-{% if test_scenario['values']['s3-use-tls'] == 'true' %}
-          - emptyDir:
-              sizeLimit: 5Mi
-            name: stackable-truststore
-{% endif %}
-          - configMap:
-              name: spark-pi-s3-1-driver-pod-template
-            name: config
-{% if lookup('env', 'VECTOR_AGGREGATOR') %}
-      vector.yaml: |
-        ---
-        data_dir: ${DATA_DIR}
+  vector.yaml: |
+    ---
+    data_dir: ${DATA_DIR}
 
-        log_schema:
-          host_key: pod
+    log_schema:
+      host_key: pod
 
-        sources:
-          # Reads the internal Vector logs
-          vector:
-            type: internal_logs
+    sources:
+      # Reads the internal Vector logs
+      vector:
+        type: internal_logs
 
-          files_stdout:
-            type: file
-            include:
-              - ${LOG_DIR}/*/*.stdout.log
+      files_stdout:
+        type: file
+        include:
+          - ${LOG_DIR}/*/*.stdout.log
 
-          files_stderr:
-            type: file
-            include:
-              - ${LOG_DIR}/*/*.stderr.log
+      files_stderr:
+        type: file
+        include:
+          - ${LOG_DIR}/*/*.stderr.log
 
-          files_log4j2:
-            type: file
-            include:
-              - ${LOG_DIR}/*/*.log4j2.xml
-            line_delimiter: "\r\n"
+      files_log4j2:
+        type: file
+        include:
+          - ${LOG_DIR}/*/*.log4j2.xml
+        line_delimiter: "\r\n"
 
-        transforms:
-          processed_files_stdout:
-            inputs:
-              - files_stdout
-            type: remap
-            source: |
-              .logger = "ROOT"
-              .level = "INFO"
+    transforms:
+      processed_files_stdout:
+        inputs:
+          - files_stdout
+        type: remap
+        source: |
+          .logger = "ROOT"
+          .level = "INFO"
 
-          processed_files_stderr:
-            inputs:
-              - files_stderr
-            type: remap
-            source: |
-              .logger = "ROOT"
-              .level = "ERROR"
+      processed_files_stderr:
+        inputs:
+          - files_stderr
+        type: remap
+        source: |
+          .logger = "ROOT"
+          .level = "ERROR"
 
-          processed_files_log4j2:
-            inputs:
-              - files_log4j2
-            type: remap
-            source: |
-              raw_message = string!(.message)
+      processed_files_log4j2:
+        inputs:
+          - files_log4j2
+        type: remap
+        source: |
+          raw_message = string!(.message)
 
-              .timestamp = now()
-              .logger = ""
-              .level = "INFO"
-              .message = ""
-              .errors = []
+          .timestamp = now()
+          .logger = ""
+          .level = "INFO"
+          .message = ""
+          .errors = []
 
-              event = {}
-              parsed_event, err = parse_xml(raw_message)
-              if err != null {
-                error = "XML not parsable: " + err
-                .errors = push(.errors, error)
-                log(error, level: "warn")
-                .message = raw_message
-              } else {
-                if !is_object(parsed_event.Event) {
-                  error = "Parsed event contains no \"Event\" tag."
-                  .errors = push(.errors, error)
-                  log(error, level: "warn")
-                  .message = raw_message
-                } else {
-                  event = object!(parsed_event.Event)
+          event = {}
+          parsed_event, err = parse_xml(raw_message)
+          if err != null {
+            error = "XML not parsable: " + err
+            .errors = push(.errors, error)
+            log(error, level: "warn")
+            .message = raw_message
+          } else {
+            if !is_object(parsed_event.Event) {
+              error = "Parsed event contains no \"Event\" tag."
+              .errors = push(.errors, error)
+              log(error, level: "warn")
+              .message = raw_message
+            } else {
+              event = object!(parsed_event.Event)
 
-                  tag_instant_valid = false
-                  instant, err = object(event.Instant)
+              tag_instant_valid = false
+              instant, err = object(event.Instant)
+              if err == null {
+                epoch_nanoseconds, err = to_int(instant.@epochSecond) * 1_000_000_000 + to_int(instant.@nanoOfSecond)
+                if err == null && epoch_nanoseconds != 0 {
+                  converted_timestamp, err = from_unix_timestamp(epoch_nanoseconds, "nanoseconds")
                   if err == null {
-                    epoch_nanoseconds, err = to_int(instant.@epochSecond) * 1_000_000_000 + to_int(instant.@nanoOfSecond)
-                    if err == null && epoch_nanoseconds != 0 {
-                      converted_timestamp, err = from_unix_timestamp(epoch_nanoseconds, "nanoseconds")
-                      if err == null {
-                        .timestamp = converted_timestamp
-                        tag_instant_valid = true
-                      } else {
-                        .errors = push(.errors, "Instant invalid, trying property timeMillis instead: " + err)
-                      }
-                    } else {
-                      .errors = push(.errors, "Instant invalid, trying property timeMillis instead: " + err)
-                    }
-                  }
-                  if !tag_instant_valid {
-                    epoch_milliseconds, err = to_int(event.@timeMillis)
-                    if err == null && epoch_milliseconds != 0 {
-                      converted_timestamp, err = from_unix_timestamp(epoch_milliseconds, "milliseconds")
-                      if err == null {
-                        .timestamp = converted_timestamp
-                      } else {
-                        .errors = push(.errors, "timeMillis not parsable, using current time instead: " + err)
-                      }
-                    } else {
-                      .errors = push(.errors, "timeMillis not parsable, using current time instead: " + err)
-                    }
-                  }
-
-                  .logger, err = string(event.@loggerName)
-                  if err != null || is_empty(.logger) {
-                    .errors = push(.errors, "Logger not found.")
-                  }
-
-                  level, err = string(event.@level)
-                  if err != null {
-                    .errors = push(.errors, "Level not found, using \"" + .level + "\" instead.")
-                  } else if !includes(["TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"], level) {
-                    .errors = push(.errors, "Level \"" + level + "\" unknown, using \"" + .level + "\" instead.")
+                    .timestamp = converted_timestamp
+                    tag_instant_valid = true
                   } else {
-                    .level = level
+                    .errors = push(.errors, "Instant invalid, trying property timeMillis instead: " + err)
                   }
-
-                  exception = null
-                  thrown = event.Thrown
-                  if is_object(thrown) {
-                    exception = "Exception"
-                    thread, err = string(event.@thread)
-                    if err == null && !is_empty(thread) {
-                      exception = exception + " in thread \"" + thread + "\""
-                    }
-                    thrown_name, err = string(thrown.@name)
-                    if err == null && !is_empty(exception) {
-                      exception = exception + " " + thrown_name
-                    }
-                    message = string(thrown.@localizedMessage) ??
-                      string(thrown.@message) ??
-                      ""
-                    if !is_empty(message) {
-                      exception = exception + ": " + message
-                    }
-                    stacktrace_items = array(thrown.ExtendedStackTrace.ExtendedStackTraceItem) ?? []
-                    stacktrace = ""
-                    for_each(stacktrace_items) -> |_index, value| {
-                      stacktrace = stacktrace + "        "
-                      class = string(value.@class) ?? ""
-                      method = string(value.@method) ?? ""
-                      if !is_empty(class) && !is_empty(method) {
-                        stacktrace = stacktrace + "at " + class + "." + method
-                      }
-                      file = string(value.@file) ?? ""
-                      line = string(value.@line) ?? ""
-                      if !is_empty(file) && !is_empty(line) {
-                        stacktrace = stacktrace + "(" + file + ":" + line + ")"
-                      }
-                      exact = to_bool(value.@exact) ?? false
-                      location = string(value.@location) ?? ""
-                      version = string(value.@version) ?? ""
-                      if !is_empty(location) && !is_empty(version) {
-                        stacktrace = stacktrace + " "
-                        if !exact {
-                          stacktrace = stacktrace + "~"
-                        }
-                        stacktrace = stacktrace + "[" + location + ":" + version + "]"
-                      }
-                      stacktrace = stacktrace + "\n"
-                    }
-                    if stacktrace != "" {
-                      exception = exception + "\n" + stacktrace
-                    }
+                } else {
+                  .errors = push(.errors, "Instant invalid, trying property timeMillis instead: " + err)
+                }
+              }
+              if !tag_instant_valid {
+                epoch_milliseconds, err = to_int(event.@timeMillis)
+                if err == null && epoch_milliseconds != 0 {
+                  converted_timestamp, err = from_unix_timestamp(epoch_milliseconds, "milliseconds")
+                  if err == null {
+                    .timestamp = converted_timestamp
+                  } else {
+                    .errors = push(.errors, "timeMillis not parsable, using current time instead: " + err)
                   }
-
-                  message, err = string(event.Message)
-                  if err != null || is_empty(message) {
-                    message = null
-                    .errors = push(.errors, "Message not found.")
-                  }
-                  .message = join!(compact([message, exception]), "\n")
+                } else {
+                  .errors = push(.errors, "timeMillis not parsable, using current time instead: " + err)
                 }
               }
 
-          # Extends the processed files with the fields "container" and "file"
-          extended_logs_files:
-            inputs:
-              - processed_files_*
-            type: remap
-            source: |
-              del(.source_type)
-              if .errors == [] {
-                del(.errors)
+              .logger, err = string(event.@loggerName)
+              if err != null || is_empty(.logger) {
+                .errors = push(.errors, "Logger not found.")
               }
-              . |= parse_regex!(.file, r'^${LOG_DIR}/(?P<container>.*?)/(?P<file>.*?)$')
 
-          # Filters the logs of the Vector agent according to the defined log level
-          filtered_logs_vector:
-            inputs:
-              - vector
-            type: filter
-            condition: >
-              (.metadata.level == "TRACE" && "${VECTOR_FILE_LOG_LEVEL}" == "trace") ||
-              (.metadata.level == "DEBUG" && includes(["trace", "debug"], "${VECTOR_FILE_LOG_LEVEL}")) ||
-              (.metadata.level == "INFO" && includes(["trace", "debug", "info"], "${VECTOR_FILE_LOG_LEVEL}")) ||
-              (.metadata.level == "WARN" && includes(["trace", "debug", "info", "warn"], "${VECTOR_FILE_LOG_LEVEL}")) ||
-              (.metadata.level == "ERROR" && includes(["trace", "debug", "info", "warn", "error"], "${VECTOR_FILE_LOG_LEVEL}"))
-
-          # Aligns the logs of the Vector agent with the common format
-          extended_logs_vector:
-            inputs:
-              - filtered_logs_vector
-            type: remap
-            source: |
-              .container = "vector"
-              .level = .metadata.level
-              .logger = .metadata.module_path
-              if exists(.file) { .processed_file = del(.file) }
-              del(.metadata)
-              del(.pid)
-              del(.source_type)
-
-          # Add the fields "namespace", "cluster", "role" and "roleGroup" to all logs
-          extended_logs:
-            inputs:
-              - extended_logs_*
-            type: remap
-            source: |
-              .namespace = "${NAMESPACE}"
-              .cluster = "${CLUSTER_NAME}"
-              .role = "${ROLE_NAME}"
-              .roleGroup = "${ROLE_GROUP_NAME}"
-
-        sinks:
-          # Forward the logs to the Vector aggregator
-          aggregator:
-            inputs:
-              - extended_logs
-            type: vector
-            address: ${VECTOR_AGGREGATOR_ADDRESS}
-{% endif %}
-      YAMLEOF
-      )
-      actual=$(kubectl -n $NAMESPACE get cm spark-pi-s3-1-driver-pod-template -o yaml | yq -o=json '.data')
-      expected_file=$(mktemp) && actual_file=$(mktemp)
-      printf '%s\n' "$expected" > "$expected_file"
-      printf '%s\n' "$actual" > "$actual_file"
-      if ! diff_out=$(diff -u "$expected_file" "$actual_file"); then
-        echo "ERROR: ConfigMap spark-pi-s3-1-driver-pod-template data drifted from snapshot."
-        printf '%s\n' "$diff_out"
-        rm -f "$expected_file" "$actual_file"
-        exit 1
-      fi
-      rm -f "$expected_file" "$actual_file"
-  - script: |
-      expected=$(cat <<'YAMLEOF' | sed "s|__NAMESPACE__|$NAMESPACE|g" | yq -o=json
-      log4j2.properties: |-
-        appenders = FILE, CONSOLE
-
-        appender.CONSOLE.type = Console
-        appender.CONSOLE.name = CONSOLE
-        appender.CONSOLE.target = SYSTEM_ERR
-        appender.CONSOLE.layout.type = PatternLayout
-        appender.CONSOLE.layout.pattern = %d{ISO8601} %p [%t] %c - %m%n
-        appender.CONSOLE.filter.threshold.type = ThresholdFilter
-        appender.CONSOLE.filter.threshold.level = INFO
-
-        appender.FILE.type = RollingFile
-        appender.FILE.name = FILE
-        appender.FILE.fileName = /stackable/log/spark/spark.log4j2.xml
-        appender.FILE.filePattern = /stackable/log/spark/spark.log4j2.xml.%i
-        appender.FILE.layout.type = XMLLayout
-        appender.FILE.policies.type = Policies
-        appender.FILE.policies.size.type = SizeBasedTriggeringPolicy
-        appender.FILE.policies.size.size = 5MB
-        appender.FILE.strategy.type = DefaultRolloverStrategy
-        appender.FILE.strategy.max = 1
-        appender.FILE.filter.threshold.type = ThresholdFilter
-        appender.FILE.filter.threshold.level = INFO
-
-
-        rootLogger.level=INFO
-        rootLogger.appenderRefs = CONSOLE, FILE
-        rootLogger.appenderRef.CONSOLE.ref = CONSOLE
-        rootLogger.appenderRef.FILE.ref = FILE
-      security.properties: |
-        networkaddress.cache.negative.ttl=0
-        networkaddress.cache.ttl=30
-      spark-env.sh: ""
-      template.yaml: |
-        metadata:
-          labels:
-            app.kubernetes.io/component: spark
-            app.kubernetes.io/instance: spark-pi-s3-1
-            app.kubernetes.io/managed-by: spark.stackable.tech_sparkapplication
-            app.kubernetes.io/name: spark-k8s
-            app.kubernetes.io/role-group: sparkapplication
-            app.kubernetes.io/version: {{ test_scenario['values']['spark'].split(',')[0] }}-stackable0.0.0-dev
-            stackable.tech/vendor: Stackable
-          name: spark
-        spec:
-          affinity: {}
-          containers:
-          - env:
-            - name: CONTAINERDEBUG_LOG_DIRECTORY
-              value: /stackable/log/containerdebug
-{% if test_scenario['values']['s3-use-tls'] == 'true' %}
-            - name: STACKABLE_TLS_STORE_PASSWORD
-              value: changeit
-{% endif %}
-            - name: _STACKABLE_PRE_HOOK
-              value: containerdebug --output=/stackable/log/containerdebug-state.json --loop &
-{% if lookup('env', 'VECTOR_AGGREGATOR') %}
-            - name: _STACKABLE_POST_HOOK
-              value: sleep 10; mkdir -p /stackable/log/_vector && touch /stackable/log/_vector/shutdown
-{% endif %}
-            image: oci.stackable.tech/sdp/spark-k8s:{{ test_scenario['values']['spark'].split(',')[0] }}-stackable0.0.0-dev
-            imagePullPolicy: IfNotPresent
-            name: spark
-            resources:
-              limits:
-                cpu: '1'
-                memory: 1Gi
-              requests:
-                cpu: 250m
-                memory: 1Gi
-            volumeMounts:
-            - mountPath: /stackable/secrets/s3-credentials-class
-              name: s3-credentials-class
-            - mountPath: /stackable/secrets/history-credentials-class
-              name: history-credentials-class
-            - mountPath: /stackable/log_config
-              name: log-config
-            - mountPath: /stackable/log
-              name: log
-{% if test_scenario['values']['s3-use-tls'] == 'true' %}
-            - mountPath: /stackable/truststore
-              name: stackable-truststore
-            - mountPath: /stackable/mount_server_tls/minio-tls-eventlog
-              name: minio-tls-eventlog
-{% endif %}
-{% if lookup('env', 'VECTOR_AGGREGATOR') %}
-          - args:
-            - |-
-              mkdir --parents /stackable/log/_vector-state
-              # Vector will ignore SIGTERM (as PID != 1) and must be shut down by writing a shutdown trigger file
-              vector & vector_pid=$!
-              if [ ! -f "/stackable/log/_vector/shutdown" ]; then
-              mkdir -p /stackable/log/_vector
-              inotifywait -qq --event create /stackable/log/_vector;
-              fi
-              sleep 1
-              kill $vector_pid
-            command:
-            - /bin/bash
-            - -x
-            - -euo
-            - pipefail
-            - -c
-            env:
-            - name: CLUSTER_NAME
-              value: spark-pi-s3-1
-            - name: DATA_DIR
-              value: /stackable/log/_vector-state
-            - name: LOG_DIR
-              value: /stackable/log
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: ROLE_GROUP_NAME
-              value: default
-            - name: ROLE_NAME
-              value: executor
-            - name: VECTOR_AGGREGATOR_ADDRESS
-              valueFrom:
-                configMapKeyRef:
-                  key: ADDRESS
-                  name: vector-aggregator-discovery
-            - name: VECTOR_CONFIG_YAML
-              value: /stackable/config/vector.yaml
-            - name: VECTOR_FILE_LOG_LEVEL
-              value: info
-            - name: VECTOR_LOG
-              value: info
-            image: oci.stackable.tech/sdp/spark-k8s:{{ test_scenario['values']['spark'].split(',')[0] }}-stackable0.0.0-dev
-            imagePullPolicy: IfNotPresent
-            name: vector
-            resources:
-              limits:
-                cpu: 500m
-                memory: 128Mi
-              requests:
-                cpu: 250m
-                memory: 128Mi
-            volumeMounts:
-            - mountPath: /stackable/config/vector.yaml
-              name: config
-              readOnly: true
-              subPath: vector.yaml
-            - mountPath: /stackable/log
-              name: log
-{% endif %}
-          enableServiceLinks: false
-{% if test_scenario['values']['s3-use-tls'] == 'true' %}
-          initContainers:
-          - args:
-            - |-
-              cert-tools generate-pkcs12-truststore --pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem --out /stackable/truststore/truststore.p12 --out-password changeit
-              cert-tools generate-pkcs12-truststore --pkcs12 /stackable/truststore/truststore.p12:changeit --pkcs12 /stackable/mount_server_tls/minio-tls-eventlog/truststore.p12 --out /stackable/truststore/truststore.p12 --out-password changeit
-            command:
-            - /bin/bash
-            - -x
-            - -euo
-            - pipefail
-            - -c
-            image: oci.stackable.tech/sdp/spark-k8s:{{ test_scenario['values']['spark'].split(',')[0] }}-stackable0.0.0-dev
-            name: tls
-            resources:
-              limits:
-                cpu: 1000m
-                memory: 1024Mi
-              requests:
-                cpu: 250m
-                memory: 1024Mi
-            volumeMounts:
-            - mountPath: /stackable/mount_server_tls/minio-tls-eventlog
-              name: minio-tls-eventlog
-            - mountPath: /stackable/truststore
-              name: stackable-truststore
-{% endif %}
-          securityContext:
-            fsGroup: 1000
-          serviceAccountName: spark-pi-s3-1
-          volumes:
-          - ephemeral:
-              volumeClaimTemplate:
-                metadata:
-                  annotations:
-                    secrets.stackable.tech/class: history-credentials-class
-                    secrets.stackable.tech/provision-parts: public-private
-                spec:
-                  accessModes:
-                  - ReadWriteOnce
-                  resources:
-                    requests:
-                      storage: '1'
-                  storageClassName: secrets.stackable.tech
-            name: history-credentials-class
-          - emptyDir:
-              sizeLimit: 39Mi
-            name: log
-          - configMap:
-              name: spark-pi-s3-1-executor-pod-template
-            name: log-config
-{% if test_scenario['values']['s3-use-tls'] == 'true' %}
-          - ephemeral:
-              volumeClaimTemplate:
-                metadata:
-                  annotations:
-                    secrets.stackable.tech/backend.autotls.cert.lifetime: 1d
-                    secrets.stackable.tech/class: minio-tls-eventlog
-                    secrets.stackable.tech/format: tls-pkcs12
-                    secrets.stackable.tech/provision-parts: public
-                spec:
-                  accessModes:
-                  - ReadWriteOnce
-                  resources:
-                    requests:
-                      storage: '1'
-                  storageClassName: secrets.stackable.tech
-            name: minio-tls-eventlog
-{% endif %}
-          - ephemeral:
-              volumeClaimTemplate:
-                metadata:
-                  annotations:
-                    secrets.stackable.tech/class: s3-credentials-class
-                    secrets.stackable.tech/provision-parts: public-private
-                spec:
-                  accessModes:
-                  - ReadWriteOnce
-                  resources:
-                    requests:
-                      storage: '1'
-                  storageClassName: secrets.stackable.tech
-            name: s3-credentials-class
-{% if test_scenario['values']['s3-use-tls'] == 'true' %}
-          - emptyDir:
-              sizeLimit: 5Mi
-            name: stackable-truststore
-{% endif %}
-          - configMap:
-              name: spark-pi-s3-1-executor-pod-template
-            name: config
-{% if lookup('env', 'VECTOR_AGGREGATOR') %}
-      vector.yaml: |
-        ---
-        data_dir: ${DATA_DIR}
-
-        log_schema:
-          host_key: pod
-
-        sources:
-          # Reads the internal Vector logs
-          vector:
-            type: internal_logs
-
-          files_stdout:
-            type: file
-            include:
-              - ${LOG_DIR}/*/*.stdout.log
-
-          files_stderr:
-            type: file
-            include:
-              - ${LOG_DIR}/*/*.stderr.log
-
-          files_log4j2:
-            type: file
-            include:
-              - ${LOG_DIR}/*/*.log4j2.xml
-            line_delimiter: "\r\n"
-
-        transforms:
-          processed_files_stdout:
-            inputs:
-              - files_stdout
-            type: remap
-            source: |
-              .logger = "ROOT"
-              .level = "INFO"
-
-          processed_files_stderr:
-            inputs:
-              - files_stderr
-            type: remap
-            source: |
-              .logger = "ROOT"
-              .level = "ERROR"
-
-          processed_files_log4j2:
-            inputs:
-              - files_log4j2
-            type: remap
-            source: |
-              raw_message = string!(.message)
-
-              .timestamp = now()
-              .logger = ""
-              .level = "INFO"
-              .message = ""
-              .errors = []
-
-              event = {}
-              parsed_event, err = parse_xml(raw_message)
+              level, err = string(event.@level)
               if err != null {
-                error = "XML not parsable: " + err
-                .errors = push(.errors, error)
-                log(error, level: "warn")
-                .message = raw_message
+                .errors = push(.errors, "Level not found, using \"" + .level + "\" instead.")
+              } else if !includes(["TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"], level) {
+                .errors = push(.errors, "Level \"" + level + "\" unknown, using \"" + .level + "\" instead.")
               } else {
-                if !is_object(parsed_event.Event) {
-                  error = "Parsed event contains no \"Event\" tag."
-                  .errors = push(.errors, error)
-                  log(error, level: "warn")
-                  .message = raw_message
-                } else {
-                  event = object!(parsed_event.Event)
+                .level = level
+              }
 
-                  tag_instant_valid = false
-                  instant, err = object(event.Instant)
-                  if err == null {
-                    epoch_nanoseconds, err = to_int(instant.@epochSecond) * 1_000_000_000 + to_int(instant.@nanoOfSecond)
-                    if err == null && epoch_nanoseconds != 0 {
-                      converted_timestamp, err = from_unix_timestamp(epoch_nanoseconds, "nanoseconds")
-                      if err == null {
-                        .timestamp = converted_timestamp
-                        tag_instant_valid = true
-                      } else {
-                        .errors = push(.errors, "Instant invalid, trying property timeMillis instead: " + err)
-                      }
-                    } else {
-                      .errors = push(.errors, "Instant invalid, trying property timeMillis instead: " + err)
-                    }
+              exception = null
+              thrown = event.Thrown
+              if is_object(thrown) {
+                exception = "Exception"
+                thread, err = string(event.@thread)
+                if err == null && !is_empty(thread) {
+                  exception = exception + " in thread \"" + thread + "\""
+                }
+                thrown_name, err = string(thrown.@name)
+                if err == null && !is_empty(exception) {
+                  exception = exception + " " + thrown_name
+                }
+                message = string(thrown.@localizedMessage) ??
+                  string(thrown.@message) ??
+                  ""
+                if !is_empty(message) {
+                  exception = exception + ": " + message
+                }
+                stacktrace_items = array(thrown.ExtendedStackTrace.ExtendedStackTraceItem) ?? []
+                stacktrace = ""
+                for_each(stacktrace_items) -> |_index, value| {
+                  stacktrace = stacktrace + "        "
+                  class = string(value.@class) ?? ""
+                  method = string(value.@method) ?? ""
+                  if !is_empty(class) && !is_empty(method) {
+                    stacktrace = stacktrace + "at " + class + "." + method
                   }
-                  if !tag_instant_valid {
-                    epoch_milliseconds, err = to_int(event.@timeMillis)
-                    if err == null && epoch_milliseconds != 0 {
-                      converted_timestamp, err = from_unix_timestamp(epoch_milliseconds, "milliseconds")
-                      if err == null {
-                        .timestamp = converted_timestamp
-                      } else {
-                        .errors = push(.errors, "timeMillis not parsable, using current time instead: " + err)
-                      }
-                    } else {
-                      .errors = push(.errors, "timeMillis not parsable, using current time instead: " + err)
-                    }
+                  file = string(value.@file) ?? ""
+                  line = string(value.@line) ?? ""
+                  if !is_empty(file) && !is_empty(line) {
+                    stacktrace = stacktrace + "(" + file + ":" + line + ")"
                   }
-
-                  .logger, err = string(event.@loggerName)
-                  if err != null || is_empty(.logger) {
-                    .errors = push(.errors, "Logger not found.")
+                  exact = to_bool(value.@exact) ?? false
+                  location = string(value.@location) ?? ""
+                  version = string(value.@version) ?? ""
+                  if !is_empty(location) && !is_empty(version) {
+                    stacktrace = stacktrace + " "
+                    if !exact {
+                      stacktrace = stacktrace + "~"
+                    }
+                    stacktrace = stacktrace + "[" + location + ":" + version + "]"
                   }
-
-                  level, err = string(event.@level)
-                  if err != null {
-                    .errors = push(.errors, "Level not found, using \"" + .level + "\" instead.")
-                  } else if !includes(["TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"], level) {
-                    .errors = push(.errors, "Level \"" + level + "\" unknown, using \"" + .level + "\" instead.")
-                  } else {
-                    .level = level
-                  }
-
-                  exception = null
-                  thrown = event.Thrown
-                  if is_object(thrown) {
-                    exception = "Exception"
-                    thread, err = string(event.@thread)
-                    if err == null && !is_empty(thread) {
-                      exception = exception + " in thread \"" + thread + "\""
-                    }
-                    thrown_name, err = string(thrown.@name)
-                    if err == null && !is_empty(exception) {
-                      exception = exception + " " + thrown_name
-                    }
-                    message = string(thrown.@localizedMessage) ??
-                      string(thrown.@message) ??
-                      ""
-                    if !is_empty(message) {
-                      exception = exception + ": " + message
-                    }
-                    stacktrace_items = array(thrown.ExtendedStackTrace.ExtendedStackTraceItem) ?? []
-                    stacktrace = ""
-                    for_each(stacktrace_items) -> |_index, value| {
-                      stacktrace = stacktrace + "        "
-                      class = string(value.@class) ?? ""
-                      method = string(value.@method) ?? ""
-                      if !is_empty(class) && !is_empty(method) {
-                        stacktrace = stacktrace + "at " + class + "." + method
-                      }
-                      file = string(value.@file) ?? ""
-                      line = string(value.@line) ?? ""
-                      if !is_empty(file) && !is_empty(line) {
-                        stacktrace = stacktrace + "(" + file + ":" + line + ")"
-                      }
-                      exact = to_bool(value.@exact) ?? false
-                      location = string(value.@location) ?? ""
-                      version = string(value.@version) ?? ""
-                      if !is_empty(location) && !is_empty(version) {
-                        stacktrace = stacktrace + " "
-                        if !exact {
-                          stacktrace = stacktrace + "~"
-                        }
-                        stacktrace = stacktrace + "[" + location + ":" + version + "]"
-                      }
-                      stacktrace = stacktrace + "\n"
-                    }
-                    if stacktrace != "" {
-                      exception = exception + "\n" + stacktrace
-                    }
-                  }
-
-                  message, err = string(event.Message)
-                  if err != null || is_empty(message) {
-                    message = null
-                    .errors = push(.errors, "Message not found.")
-                  }
-                  .message = join!(compact([message, exception]), "\n")
+                  stacktrace = stacktrace + "\n"
+                }
+                if stacktrace != "" {
+                  exception = exception + "\n" + stacktrace
                 }
               }
 
-          # Extends the processed files with the fields "container" and "file"
-          extended_logs_files:
-            inputs:
-              - processed_files_*
-            type: remap
-            source: |
-              del(.source_type)
-              if .errors == [] {
-                del(.errors)
+              message, err = string(event.Message)
+              if err != null || is_empty(message) {
+                message = null
+                .errors = push(.errors, "Message not found.")
               }
-              . |= parse_regex!(.file, r'^${LOG_DIR}/(?P<container>.*?)/(?P<file>.*?)$')
+              .message = join!(compact([message, exception]), "\n")
+            }
+          }
 
-          # Filters the logs of the Vector agent according to the defined log level
-          filtered_logs_vector:
-            inputs:
-              - vector
-            type: filter
-            condition: >
-              (.metadata.level == "TRACE" && "${VECTOR_FILE_LOG_LEVEL}" == "trace") ||
-              (.metadata.level == "DEBUG" && includes(["trace", "debug"], "${VECTOR_FILE_LOG_LEVEL}")) ||
-              (.metadata.level == "INFO" && includes(["trace", "debug", "info"], "${VECTOR_FILE_LOG_LEVEL}")) ||
-              (.metadata.level == "WARN" && includes(["trace", "debug", "info", "warn"], "${VECTOR_FILE_LOG_LEVEL}")) ||
-              (.metadata.level == "ERROR" && includes(["trace", "debug", "info", "warn", "error"], "${VECTOR_FILE_LOG_LEVEL}"))
+      # Extends the processed files with the fields "container" and "file"
+      extended_logs_files:
+        inputs:
+          - processed_files_*
+        type: remap
+        source: |
+          del(.source_type)
+          if .errors == [] {
+            del(.errors)
+          }
+          . |= parse_regex!(.file, r'^${LOG_DIR}/(?P<container>.*?)/(?P<file>.*?)$')
 
-          # Aligns the logs of the Vector agent with the common format
-          extended_logs_vector:
-            inputs:
-              - filtered_logs_vector
-            type: remap
-            source: |
-              .container = "vector"
-              .level = .metadata.level
-              .logger = .metadata.module_path
-              if exists(.file) { .processed_file = del(.file) }
-              del(.metadata)
-              del(.pid)
-              del(.source_type)
+      # Filters the logs of the Vector agent according to the defined log level
+      filtered_logs_vector:
+        inputs:
+          - vector
+        type: filter
+        condition: >
+          (.metadata.level == "TRACE" && "${VECTOR_FILE_LOG_LEVEL}" == "trace") ||
+          (.metadata.level == "DEBUG" && includes(["trace", "debug"], "${VECTOR_FILE_LOG_LEVEL}")) ||
+          (.metadata.level == "INFO" && includes(["trace", "debug", "info"], "${VECTOR_FILE_LOG_LEVEL}")) ||
+          (.metadata.level == "WARN" && includes(["trace", "debug", "info", "warn"], "${VECTOR_FILE_LOG_LEVEL}")) ||
+          (.metadata.level == "ERROR" && includes(["trace", "debug", "info", "warn", "error"], "${VECTOR_FILE_LOG_LEVEL}"))
 
-          # Add the fields "namespace", "cluster", "role" and "roleGroup" to all logs
-          extended_logs:
-            inputs:
-              - extended_logs_*
-            type: remap
-            source: |
-              .namespace = "${NAMESPACE}"
-              .cluster = "${CLUSTER_NAME}"
-              .role = "${ROLE_NAME}"
-              .roleGroup = "${ROLE_GROUP_NAME}"
+      # Aligns the logs of the Vector agent with the common format
+      extended_logs_vector:
+        inputs:
+          - filtered_logs_vector
+        type: remap
+        source: |
+          .container = "vector"
+          .level = .metadata.level
+          .logger = .metadata.module_path
+          if exists(.file) { .processed_file = del(.file) }
+          del(.metadata)
+          del(.pid)
+          del(.source_type)
 
-        sinks:
-          # Forward the logs to the Vector aggregator
-          aggregator:
-            inputs:
-              - extended_logs
-            type: vector
-            address: ${VECTOR_AGGREGATOR_ADDRESS}
+      # Add the fields "namespace", "cluster", "role" and "roleGroup" to all logs
+      extended_logs:
+        inputs:
+          - extended_logs_*
+        type: remap
+        source: |
+          .namespace = "${NAMESPACE}"
+          .cluster = "${CLUSTER_NAME}"
+          .role = "${ROLE_NAME}"
+          .roleGroup = "${ROLE_GROUP_NAME}"
+
+    sinks:
+      # Forward the logs to the Vector aggregator
+      aggregator:
+        inputs:
+          - extended_logs
+        type: vector
+        address: ${VECTOR_AGGREGATOR_ADDRESS}
 {% endif %}
-      YAMLEOF
-      )
-      actual=$(kubectl -n $NAMESPACE get cm spark-pi-s3-1-executor-pod-template -o yaml | yq -o=json '.data')
-      expected_file=$(mktemp) && actual_file=$(mktemp)
-      printf '%s\n' "$expected" > "$expected_file"
-      printf '%s\n' "$actual" > "$actual_file"
-      if ! diff_out=$(diff -u "$expected_file" "$actual_file"); then
-        echo "ERROR: ConfigMap spark-pi-s3-1-executor-pod-template data drifted from snapshot."
-        printf '%s\n' "$diff_out"
-        rm -f "$expected_file" "$actual_file"
-        exit 1
-      fi
-      rm -f "$expected_file" "$actual_file"
-  - script: |
-      expected=$(cat <<'YAMLEOF' | yq -o=json
-      security.properties: |
-        networkaddress.cache.negative.ttl=0
-        networkaddress.cache.ttl=30
-      spark-env.sh: ""
-      YAMLEOF
-      )
-      actual=$(kubectl -n $NAMESPACE get cm spark-pi-s3-1-submit-job -o yaml | yq -o=json '.data')
-      expected_file=$(mktemp) && actual_file=$(mktemp)
-      printf '%s\n' "$expected" > "$expected_file"
-      printf '%s\n' "$actual" > "$actual_file"
-      if ! diff_out=$(diff -u "$expected_file" "$actual_file"); then
-        echo "ERROR: ConfigMap spark-pi-s3-1-submit-job data drifted from snapshot."
-        printf '%s\n' "$diff_out"
-        rm -f "$expected_file" "$actual_file"
-        exit 1
-      fi
-      rm -f "$expected_file" "$actual_file"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spark-pi-s3-1-executor-pod-template
+data:
+  log4j2.properties: |-
+    appenders = FILE, CONSOLE
+
+    appender.CONSOLE.type = Console
+    appender.CONSOLE.name = CONSOLE
+    appender.CONSOLE.target = SYSTEM_ERR
+    appender.CONSOLE.layout.type = PatternLayout
+    appender.CONSOLE.layout.pattern = %d{ISO8601} %p [%t] %c - %m%n
+    appender.CONSOLE.filter.threshold.type = ThresholdFilter
+    appender.CONSOLE.filter.threshold.level = INFO
+
+    appender.FILE.type = RollingFile
+    appender.FILE.name = FILE
+    appender.FILE.fileName = /stackable/log/spark/spark.log4j2.xml
+    appender.FILE.filePattern = /stackable/log/spark/spark.log4j2.xml.%i
+    appender.FILE.layout.type = XMLLayout
+    appender.FILE.policies.type = Policies
+    appender.FILE.policies.size.type = SizeBasedTriggeringPolicy
+    appender.FILE.policies.size.size = 5MB
+    appender.FILE.strategy.type = DefaultRolloverStrategy
+    appender.FILE.strategy.max = 1
+    appender.FILE.filter.threshold.type = ThresholdFilter
+    appender.FILE.filter.threshold.level = INFO
+
+
+    rootLogger.level=INFO
+    rootLogger.appenderRefs = CONSOLE, FILE
+    rootLogger.appenderRef.CONSOLE.ref = CONSOLE
+    rootLogger.appenderRef.FILE.ref = FILE
+  security.properties: |
+    networkaddress.cache.negative.ttl=0
+    networkaddress.cache.ttl=30
+  spark-env.sh: ""
+{% if lookup('env', 'VECTOR_AGGREGATOR') %}
+  vector.yaml: |
+    ---
+    data_dir: ${DATA_DIR}
+
+    log_schema:
+      host_key: pod
+
+    sources:
+      # Reads the internal Vector logs
+      vector:
+        type: internal_logs
+
+      files_stdout:
+        type: file
+        include:
+          - ${LOG_DIR}/*/*.stdout.log
+
+      files_stderr:
+        type: file
+        include:
+          - ${LOG_DIR}/*/*.stderr.log
+
+      files_log4j2:
+        type: file
+        include:
+          - ${LOG_DIR}/*/*.log4j2.xml
+        line_delimiter: "\r\n"
+
+    transforms:
+      processed_files_stdout:
+        inputs:
+          - files_stdout
+        type: remap
+        source: |
+          .logger = "ROOT"
+          .level = "INFO"
+
+      processed_files_stderr:
+        inputs:
+          - files_stderr
+        type: remap
+        source: |
+          .logger = "ROOT"
+          .level = "ERROR"
+
+      processed_files_log4j2:
+        inputs:
+          - files_log4j2
+        type: remap
+        source: |
+          raw_message = string!(.message)
+
+          .timestamp = now()
+          .logger = ""
+          .level = "INFO"
+          .message = ""
+          .errors = []
+
+          event = {}
+          parsed_event, err = parse_xml(raw_message)
+          if err != null {
+            error = "XML not parsable: " + err
+            .errors = push(.errors, error)
+            log(error, level: "warn")
+            .message = raw_message
+          } else {
+            if !is_object(parsed_event.Event) {
+              error = "Parsed event contains no \"Event\" tag."
+              .errors = push(.errors, error)
+              log(error, level: "warn")
+              .message = raw_message
+            } else {
+              event = object!(parsed_event.Event)
+
+              tag_instant_valid = false
+              instant, err = object(event.Instant)
+              if err == null {
+                epoch_nanoseconds, err = to_int(instant.@epochSecond) * 1_000_000_000 + to_int(instant.@nanoOfSecond)
+                if err == null && epoch_nanoseconds != 0 {
+                  converted_timestamp, err = from_unix_timestamp(epoch_nanoseconds, "nanoseconds")
+                  if err == null {
+                    .timestamp = converted_timestamp
+                    tag_instant_valid = true
+                  } else {
+                    .errors = push(.errors, "Instant invalid, trying property timeMillis instead: " + err)
+                  }
+                } else {
+                  .errors = push(.errors, "Instant invalid, trying property timeMillis instead: " + err)
+                }
+              }
+              if !tag_instant_valid {
+                epoch_milliseconds, err = to_int(event.@timeMillis)
+                if err == null && epoch_milliseconds != 0 {
+                  converted_timestamp, err = from_unix_timestamp(epoch_milliseconds, "milliseconds")
+                  if err == null {
+                    .timestamp = converted_timestamp
+                  } else {
+                    .errors = push(.errors, "timeMillis not parsable, using current time instead: " + err)
+                  }
+                } else {
+                  .errors = push(.errors, "timeMillis not parsable, using current time instead: " + err)
+                }
+              }
+
+              .logger, err = string(event.@loggerName)
+              if err != null || is_empty(.logger) {
+                .errors = push(.errors, "Logger not found.")
+              }
+
+              level, err = string(event.@level)
+              if err != null {
+                .errors = push(.errors, "Level not found, using \"" + .level + "\" instead.")
+              } else if !includes(["TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"], level) {
+                .errors = push(.errors, "Level \"" + level + "\" unknown, using \"" + .level + "\" instead.")
+              } else {
+                .level = level
+              }
+
+              exception = null
+              thrown = event.Thrown
+              if is_object(thrown) {
+                exception = "Exception"
+                thread, err = string(event.@thread)
+                if err == null && !is_empty(thread) {
+                  exception = exception + " in thread \"" + thread + "\""
+                }
+                thrown_name, err = string(thrown.@name)
+                if err == null && !is_empty(exception) {
+                  exception = exception + " " + thrown_name
+                }
+                message = string(thrown.@localizedMessage) ??
+                  string(thrown.@message) ??
+                  ""
+                if !is_empty(message) {
+                  exception = exception + ": " + message
+                }
+                stacktrace_items = array(thrown.ExtendedStackTrace.ExtendedStackTraceItem) ?? []
+                stacktrace = ""
+                for_each(stacktrace_items) -> |_index, value| {
+                  stacktrace = stacktrace + "        "
+                  class = string(value.@class) ?? ""
+                  method = string(value.@method) ?? ""
+                  if !is_empty(class) && !is_empty(method) {
+                    stacktrace = stacktrace + "at " + class + "." + method
+                  }
+                  file = string(value.@file) ?? ""
+                  line = string(value.@line) ?? ""
+                  if !is_empty(file) && !is_empty(line) {
+                    stacktrace = stacktrace + "(" + file + ":" + line + ")"
+                  }
+                  exact = to_bool(value.@exact) ?? false
+                  location = string(value.@location) ?? ""
+                  version = string(value.@version) ?? ""
+                  if !is_empty(location) && !is_empty(version) {
+                    stacktrace = stacktrace + " "
+                    if !exact {
+                      stacktrace = stacktrace + "~"
+                    }
+                    stacktrace = stacktrace + "[" + location + ":" + version + "]"
+                  }
+                  stacktrace = stacktrace + "\n"
+                }
+                if stacktrace != "" {
+                  exception = exception + "\n" + stacktrace
+                }
+              }
+
+              message, err = string(event.Message)
+              if err != null || is_empty(message) {
+                message = null
+                .errors = push(.errors, "Message not found.")
+              }
+              .message = join!(compact([message, exception]), "\n")
+            }
+          }
+
+      # Extends the processed files with the fields "container" and "file"
+      extended_logs_files:
+        inputs:
+          - processed_files_*
+        type: remap
+        source: |
+          del(.source_type)
+          if .errors == [] {
+            del(.errors)
+          }
+          . |= parse_regex!(.file, r'^${LOG_DIR}/(?P<container>.*?)/(?P<file>.*?)$')
+
+      # Filters the logs of the Vector agent according to the defined log level
+      filtered_logs_vector:
+        inputs:
+          - vector
+        type: filter
+        condition: >
+          (.metadata.level == "TRACE" && "${VECTOR_FILE_LOG_LEVEL}" == "trace") ||
+          (.metadata.level == "DEBUG" && includes(["trace", "debug"], "${VECTOR_FILE_LOG_LEVEL}")) ||
+          (.metadata.level == "INFO" && includes(["trace", "debug", "info"], "${VECTOR_FILE_LOG_LEVEL}")) ||
+          (.metadata.level == "WARN" && includes(["trace", "debug", "info", "warn"], "${VECTOR_FILE_LOG_LEVEL}")) ||
+          (.metadata.level == "ERROR" && includes(["trace", "debug", "info", "warn", "error"], "${VECTOR_FILE_LOG_LEVEL}"))
+
+      # Aligns the logs of the Vector agent with the common format
+      extended_logs_vector:
+        inputs:
+          - filtered_logs_vector
+        type: remap
+        source: |
+          .container = "vector"
+          .level = .metadata.level
+          .logger = .metadata.module_path
+          if exists(.file) { .processed_file = del(.file) }
+          del(.metadata)
+          del(.pid)
+          del(.source_type)
+
+      # Add the fields "namespace", "cluster", "role" and "roleGroup" to all logs
+      extended_logs:
+        inputs:
+          - extended_logs_*
+        type: remap
+        source: |
+          .namespace = "${NAMESPACE}"
+          .cluster = "${CLUSTER_NAME}"
+          .role = "${ROLE_NAME}"
+          .roleGroup = "${ROLE_GROUP_NAME}"
+
+    sinks:
+      # Forward the logs to the Vector aggregator
+      aggregator:
+        inputs:
+          - extended_logs
+        type: vector
+        address: ${VECTOR_AGGREGATOR_ADDRESS}
+{% endif %}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spark-pi-s3-1-submit-job
+data:
+  security.properties: |
+    networkaddress.cache.negative.ttl=0
+    networkaddress.cache.ttl=30
+  spark-env.sh: ""

--- a/tests/templates/kuttl/spark-connect/13-assert.yaml.j2
+++ b/tests/templates/kuttl/spark-connect/13-assert.yaml.j2
@@ -1,748 +1,513 @@
 ---
-# Snapshot the full `.data` of each operator-managed ConfigMap.
-# Any code change that alters rendered config values will fail these diffs.
+# Snapshot the `.data` of the operator-managed ConfigMaps as plain Kubernetes
+# objects and let kuttl compare them. Any code change that alters a rendered
+# config value fails this assert.
 #
-# Runs as its own step (after 10/11/12) so kuttl does not re-evaluate the heavy
-# heredoc on every 1-second readiness retry of the install step.
+# Two things to know before adding keys here:
 #
-# The heredoc is quoted (`<<'YAMLEOF'`) so shell substitution is disabled and
-# property-style escapes (`\:`, `\=`) survive verbatim. Only `__NAMESPACE__` is
-# substituted afterwards via `sed`, because kuttl tests run in a randomized
-# namespace per invocation. Both sides are normalized to canonical JSON via
-# `yq -o=json` before comparison.
+#  * kuttl compares each `.data` value as one exact string, so a single volatile
+#    line inside a value cannot be masked.
+#  * cannot test for "spark-defaults.conf"  :(
+#    This entry contains full image strings for driver and executor pods as
+#    spark properties. These images include the SDP release version as part
+#    of the tag. This version is not available to beku/kuttl and therefore
+#    cannot be templated.
+#    Since it cannot be templated, the test will fail when run from a release
+#    branch or with a custom image name.
+#  * kuttl subset-matches maps, so a key the operator newly adds to `.data` does
+#    not fail this assert. Add it below to cover it.
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 timeout: 60
-commands:
-  - script: |
-      expected=$(cat <<'YAMLEOF' | sed "s|__NAMESPACE__|$NAMESPACE|g" | yq -o=json
-      metrics.properties: |
-        *.sink.prometheusServlet.class=org.apache.spark.metrics.sink.PrometheusServlet
-        *.sink.prometheusServlet.path=/metrics/prometheus
-      security.properties: |
-        networkaddress.cache.negative.ttl=0
-        networkaddress.cache.ttl=30
-      spark-defaults.conf: |
-        spark.driver.defaultJavaOptions=-Djava.security.properties\=/stackable/spark/conf/security.properties\ -Dlog4j.configurationFile\=/stackable/log_config/log4j2.properties\ -Dmy.custom.jvm.arg\=customValue
-        spark.driver.extraClassPath=/stackable/spark/extra-jars/*\:/stackable/spark/connect/spark-connect-{{ test_scenario['values']['spark-connect'].split(',')[0] }}.jar
-{% if test_scenario['values']['s3-use-tls'] == 'true' %}
-        spark.driver.extraJavaOptions=-Djavax.net.ssl.trustStore\=/stackable/truststore/truststore.p12\ -Djavax.net.ssl.trustStorePassword\=changeit\ -Djavax.net.ssl.trustStoreType\=pkcs12
-{% endif %}
-        spark.driver.host=spark-connect-server-headless
-        spark.executor.defaultJavaOptions=-Djava.security.properties\=/stackable/spark/conf/security.properties\ -Dlog4j.configurationFile\=/stackable/log_config/log4j2.properties
-{% if test_scenario['values']['s3-use-tls'] == 'true' %}
-        spark.executor.extraJavaOptions=-Djavax.net.ssl.trustStore\=/stackable/truststore/truststore.p12\ -Djavax.net.ssl.trustStorePassword\=changeit\ -Djavax.net.ssl.trustStoreType\=pkcs12
-{% endif %}
-        spark.executor.instances=1
-        spark.executor.memory=1024M
-        spark.executor.memoryOverhead=1m
-        spark.hadoop.fs.s3a.access.key=${file\:UTF-8\:/stackable/secrets/minio-credentials-class/accessKey}
-        spark.hadoop.fs.s3a.aws.credentials.provider=org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider
-        spark.hadoop.fs.s3a.bucket.ingest-bucket.access.key=${file\:UTF-8\:/stackable/secrets/minio-credentials-class/accessKey}
-        spark.hadoop.fs.s3a.bucket.ingest-bucket.aws.credentials.provider=org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider
-{% if test_scenario['values']['s3-use-tls'] == 'true' %}
-        spark.hadoop.fs.s3a.bucket.ingest-bucket.endpoint=https\://minio\:9000/
-{% else %}
-        spark.hadoop.fs.s3a.bucket.ingest-bucket.endpoint=http\://minio\:9000/
-{% endif %}
-        spark.hadoop.fs.s3a.bucket.ingest-bucket.endpoint.region=us-east-1
-        spark.hadoop.fs.s3a.bucket.ingest-bucket.path.style.access=true
-        spark.hadoop.fs.s3a.bucket.ingest-bucket.secret.key=${file\:UTF-8\:/stackable/secrets/minio-credentials-class/secretKey}
-{% if test_scenario['values']['s3-use-tls'] == 'true' %}
-        spark.hadoop.fs.s3a.endpoint=https\://minio\:9000/
-{% else %}
-        spark.hadoop.fs.s3a.endpoint=http\://minio\:9000/
-{% endif %}
-        spark.hadoop.fs.s3a.endpoint.region=us-east-1
-        spark.hadoop.fs.s3a.path.style.access=true
-        spark.hadoop.fs.s3a.secret.key=${file\:UTF-8\:/stackable/secrets/minio-credentials-class/secretKey}
-        spark.jars.ivy=/tmp/ivy2
-        spark.kubernetes.authenticate.driver.serviceAccountName=spark-connect-serviceaccount
-        spark.kubernetes.driver.container.image=oci.stackable.tech/sdp/spark-k8s\:{{ test_scenario['values']['spark-connect'].split(',')[0] }}-stackable0.0.0-dev
-        spark.kubernetes.driver.pod.name=${env\:HOSTNAME}
-        spark.kubernetes.executor.container.image=oci.stackable.tech/sdp/spark-k8s\:{{ test_scenario['values']['spark-connect'].split(',')[0] }}-stackable0.0.0-dev
-        spark.kubernetes.executor.limit.cores=1
-        spark.kubernetes.executor.podTemplateContainerName=spark
-        spark.kubernetes.executor.podTemplateFile=/stackable/spark/conf/template.yaml
-        spark.kubernetes.executor.request.cores=1
-        spark.kubernetes.namespace=__NAMESPACE__
-        spark.metrics.conf=/stackable/spark/conf/metrics.properties
-        spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions
-        spark.ui.prometheus.enabled=true
-      template.yaml: |
-        metadata:
-          labels:
-            app.kubernetes.io/component: executor
-            app.kubernetes.io/instance: spark-connect
-            app.kubernetes.io/managed-by: spark.stackable.tech_connect
-            app.kubernetes.io/name: spark-connect
-            app.kubernetes.io/role-group: default
-            app.kubernetes.io/version: {{ test_scenario['values']['spark-connect'].split(',')[0] }}-stackable0.0.0-dev
-            stackable.tech/vendor: Stackable
-        spec:
-          affinity:
-            podAntiAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-              - podAffinityTerm:
-                  labelSelector:
-                    matchLabels:
-                      app.kubernetes.io/component: executor
-                      app.kubernetes.io/instance: spark-connect
-                      app.kubernetes.io/name: spark-connect
-                  topologyKey: kubernetes.io/hostname
-                weight: 70
-          containers:
-          - env:
-            - name: CONTAINERDEBUG_LOG_DIRECTORY
-              value: /stackable/log/containerdebug
-            name: spark
-            volumeMounts:
-            - mountPath: /stackable/spark/conf
-              name: config
-            - mountPath: /stackable/log
-              name: log
-            - mountPath: /stackable/secrets/minio-credentials-class
-              name: minio-credentials-class-s3-credentials
-{% if test_scenario['values']['s3-use-tls'] == 'true' %}
-            - mountPath: /stackable/secrets/minio-tls-ca
-              name: minio-tls-ca-ca-cert
-{% endif %}
-            - mountPath: /stackable/truststore
-              name: stackable-truststore
-            - mountPath: /stackable/log_config
-              name: log-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spark-connect-server
+data:
+  metrics.properties: |
+    *.sink.prometheusServlet.class=org.apache.spark.metrics.sink.PrometheusServlet
+    *.sink.prometheusServlet.path=/metrics/prometheus
+  security.properties: |
+    networkaddress.cache.negative.ttl=0
+    networkaddress.cache.ttl=30
 {% if lookup('env', 'VECTOR_AGGREGATOR') %}
-          - args:
-            - |-
-              mkdir --parents /stackable/log/_vector-state
-              # Vector will ignore SIGTERM (as PID != 1) and must be shut down by writing a shutdown trigger file
-              vector & vector_pid=$!
-              if [ ! -f "/stackable/log/_vector/shutdown" ]; then
-              mkdir -p /stackable/log/_vector
-              inotifywait -qq --event create /stackable/log/_vector;
-              fi
-              sleep 1
-              kill $vector_pid
-            command:
-            - /bin/bash
-            - -x
-            - -euo
-            - pipefail
-            - -c
-            env:
-            - name: CLUSTER_NAME
-              value: spark-connect
-            - name: DATA_DIR
-              value: /stackable/log/_vector-state
-            - name: LOG_DIR
-              value: /stackable/log
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: ROLE_GROUP_NAME
-              value: default
-            - name: ROLE_NAME
-              value: executor
-            - name: VECTOR_AGGREGATOR_ADDRESS
-              valueFrom:
-                configMapKeyRef:
-                  key: ADDRESS
-                  name: vector-aggregator-discovery
-            - name: VECTOR_CONFIG_YAML
-              value: /stackable/config/vector.yaml
-            - name: VECTOR_FILE_LOG_LEVEL
-              value: info
-            - name: VECTOR_LOG
-              value: info
-            image: oci.stackable.tech/sdp/spark-k8s:{{ test_scenario['values']['spark-connect'].split(',')[0] }}-stackable0.0.0-dev
-            imagePullPolicy: IfNotPresent
-            name: vector
-            resources:
-              limits:
-                cpu: 500m
-                memory: 128Mi
-              requests:
-                cpu: 250m
-                memory: 128Mi
-            volumeMounts:
-            - mountPath: /stackable/config/vector.yaml
-              name: config
-              readOnly: true
-              subPath: vector.yaml
-            - mountPath: /stackable/log
-              name: log
-{% endif %}
-          enableServiceLinks: false
-{% if test_scenario['values']['s3-use-tls'] == 'true' %}
-          initContainers:
-          - command:
-            - /bin/bash
-            - -x
-            - -euo
-            - pipefail
-            - -c
-            - cert-tools generate-pkcs12-truststore --pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem --out /stackable/truststore/truststore.p12 --out-password changeit && cert-tools generate-pkcs12-truststore --out /stackable/truststore/truststore.p12 --out-password changeit --pkcs12 /stackable/truststore/truststore.p12:changeit --pem /stackable/secrets/minio-tls-ca/ca.crt
-            image: oci.stackable.tech/sdp/spark-k8s:{{ test_scenario['values']['spark-connect'].split(',')[0] }}-stackable0.0.0-dev
-            name: tls-truststore-init
-            resources:
-              limits:
-                cpu: 10m
-                memory: 128Mi
-              requests:
-                cpu: 10m
-                memory: 128Mi
-            volumeMounts:
-            - mountPath: /stackable/secrets/minio-credentials-class
-              name: minio-credentials-class-s3-credentials
-            - mountPath: /stackable/secrets/minio-tls-ca
-              name: minio-tls-ca-ca-cert
-            - mountPath: /stackable/truststore
-              name: stackable-truststore
-{% endif %}
-          securityContext:
-            fsGroup: 1000
-          volumes:
-          - emptyDir:
-              sizeLimit: 30Mi
-            name: log
-          - configMap:
-              name: spark-connect-executor
-            name: config
-          - ephemeral:
-              volumeClaimTemplate:
-                metadata:
-                  annotations:
-                    secrets.stackable.tech/class: minio-credentials-class
-                    secrets.stackable.tech/provision-parts: public-private
-                spec:
-                  accessModes:
-                  - ReadWriteOnce
-                  resources:
-                    requests:
-                      storage: '1'
-                  storageClassName: secrets.stackable.tech
-            name: minio-credentials-class-s3-credentials
-{% if test_scenario['values']['s3-use-tls'] == 'true' %}
-          - ephemeral:
-              volumeClaimTemplate:
-                metadata:
-                  annotations:
-                    secrets.stackable.tech/class: minio-tls-ca
-                    secrets.stackable.tech/provision-parts: public
-                spec:
-                  accessModes:
-                  - ReadWriteOnce
-                  resources:
-                    requests:
-                      storage: '1'
-                  storageClassName: secrets.stackable.tech
-            name: minio-tls-ca-ca-cert
-{% endif %}
-          - emptyDir: {}
-            name: stackable-truststore
-          - configMap:
-              name: spark-connect-log-config
-            name: log-config
-{% if lookup('env', 'VECTOR_AGGREGATOR') %}
-      vector.yaml: |
-        ---
-        data_dir: ${DATA_DIR}
+  vector.yaml: |
+    ---
+    data_dir: ${DATA_DIR}
 
-        log_schema:
-          host_key: pod
+    log_schema:
+      host_key: pod
 
-        sources:
-          # Reads the internal Vector logs
-          vector:
-            type: internal_logs
+    sources:
+      # Reads the internal Vector logs
+      vector:
+        type: internal_logs
 
-          files_stdout:
-            type: file
-            include:
-              - ${LOG_DIR}/*/*.stdout.log
+      files_stdout:
+        type: file
+        include:
+          - ${LOG_DIR}/*/*.stdout.log
 
-          files_stderr:
-            type: file
-            include:
-              - ${LOG_DIR}/*/*.stderr.log
+      files_stderr:
+        type: file
+        include:
+          - ${LOG_DIR}/*/*.stderr.log
 
-          files_log4j2:
-            type: file
-            include:
-              - ${LOG_DIR}/*/*.log4j2.xml
-            line_delimiter: "\r\n"
+      files_log4j2:
+        type: file
+        include:
+          - ${LOG_DIR}/*/*.log4j2.xml
+        line_delimiter: "\r\n"
 
-        transforms:
-          processed_files_stdout:
-            inputs:
-              - files_stdout
-            type: remap
-            source: |
-              .logger = "ROOT"
-              .level = "INFO"
+    transforms:
+      processed_files_stdout:
+        inputs:
+          - files_stdout
+        type: remap
+        source: |
+          .logger = "ROOT"
+          .level = "INFO"
 
-          processed_files_stderr:
-            inputs:
-              - files_stderr
-            type: remap
-            source: |
-              .logger = "ROOT"
-              .level = "ERROR"
+      processed_files_stderr:
+        inputs:
+          - files_stderr
+        type: remap
+        source: |
+          .logger = "ROOT"
+          .level = "ERROR"
 
-          processed_files_log4j2:
-            inputs:
-              - files_log4j2
-            type: remap
-            source: |
-              raw_message = string!(.message)
+      processed_files_log4j2:
+        inputs:
+          - files_log4j2
+        type: remap
+        source: |
+          raw_message = string!(.message)
 
-              .timestamp = now()
-              .logger = ""
-              .level = "INFO"
-              .message = ""
-              .errors = []
+          .timestamp = now()
+          .logger = ""
+          .level = "INFO"
+          .message = ""
+          .errors = []
 
-              event = {}
-              parsed_event, err = parse_xml(raw_message)
-              if err != null {
-                error = "XML not parsable: " + err
-                .errors = push(.errors, error)
-                log(error, level: "warn")
-                .message = raw_message
-              } else {
-                if !is_object(parsed_event.Event) {
-                  error = "Parsed event contains no \"Event\" tag."
-                  .errors = push(.errors, error)
-                  log(error, level: "warn")
-                  .message = raw_message
-                } else {
-                  event = object!(parsed_event.Event)
+          event = {}
+          parsed_event, err = parse_xml(raw_message)
+          if err != null {
+            error = "XML not parsable: " + err
+            .errors = push(.errors, error)
+            log(error, level: "warn")
+            .message = raw_message
+          } else {
+            if !is_object(parsed_event.Event) {
+              error = "Parsed event contains no \"Event\" tag."
+              .errors = push(.errors, error)
+              log(error, level: "warn")
+              .message = raw_message
+            } else {
+              event = object!(parsed_event.Event)
 
-                  tag_instant_valid = false
-                  instant, err = object(event.Instant)
+              tag_instant_valid = false
+              instant, err = object(event.Instant)
+              if err == null {
+                epoch_nanoseconds, err = to_int(instant.@epochSecond) * 1_000_000_000 + to_int(instant.@nanoOfSecond)
+                if err == null && epoch_nanoseconds != 0 {
+                  converted_timestamp, err = from_unix_timestamp(epoch_nanoseconds, "nanoseconds")
                   if err == null {
-                    epoch_nanoseconds, err = to_int(instant.@epochSecond) * 1_000_000_000 + to_int(instant.@nanoOfSecond)
-                    if err == null && epoch_nanoseconds != 0 {
-                      converted_timestamp, err = from_unix_timestamp(epoch_nanoseconds, "nanoseconds")
-                      if err == null {
-                        .timestamp = converted_timestamp
-                        tag_instant_valid = true
-                      } else {
-                        .errors = push(.errors, "Instant invalid, trying property timeMillis instead: " + err)
-                      }
-                    } else {
-                      .errors = push(.errors, "Instant invalid, trying property timeMillis instead: " + err)
-                    }
-                  }
-                  if !tag_instant_valid {
-                    epoch_milliseconds, err = to_int(event.@timeMillis)
-                    if err == null && epoch_milliseconds != 0 {
-                      converted_timestamp, err = from_unix_timestamp(epoch_milliseconds, "milliseconds")
-                      if err == null {
-                        .timestamp = converted_timestamp
-                      } else {
-                        .errors = push(.errors, "timeMillis not parsable, using current time instead: " + err)
-                      }
-                    } else {
-                      .errors = push(.errors, "timeMillis not parsable, using current time instead: " + err)
-                    }
-                  }
-
-                  .logger, err = string(event.@loggerName)
-                  if err != null || is_empty(.logger) {
-                    .errors = push(.errors, "Logger not found.")
-                  }
-
-                  level, err = string(event.@level)
-                  if err != null {
-                    .errors = push(.errors, "Level not found, using \"" + .level + "\" instead.")
-                  } else if !includes(["TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"], level) {
-                    .errors = push(.errors, "Level \"" + level + "\" unknown, using \"" + .level + "\" instead.")
+                    .timestamp = converted_timestamp
+                    tag_instant_valid = true
                   } else {
-                    .level = level
+                    .errors = push(.errors, "Instant invalid, trying property timeMillis instead: " + err)
                   }
-
-                  exception = null
-                  thrown = event.Thrown
-                  if is_object(thrown) {
-                    exception = "Exception"
-                    thread, err = string(event.@thread)
-                    if err == null && !is_empty(thread) {
-                      exception = exception + " in thread \"" + thread + "\""
-                    }
-                    thrown_name, err = string(thrown.@name)
-                    if err == null && !is_empty(exception) {
-                      exception = exception + " " + thrown_name
-                    }
-                    message = string(thrown.@localizedMessage) ??
-                      string(thrown.@message) ??
-                      ""
-                    if !is_empty(message) {
-                      exception = exception + ": " + message
-                    }
-                    stacktrace_items = array(thrown.ExtendedStackTrace.ExtendedStackTraceItem) ?? []
-                    stacktrace = ""
-                    for_each(stacktrace_items) -> |_index, value| {
-                      stacktrace = stacktrace + "        "
-                      class = string(value.@class) ?? ""
-                      method = string(value.@method) ?? ""
-                      if !is_empty(class) && !is_empty(method) {
-                        stacktrace = stacktrace + "at " + class + "." + method
-                      }
-                      file = string(value.@file) ?? ""
-                      line = string(value.@line) ?? ""
-                      if !is_empty(file) && !is_empty(line) {
-                        stacktrace = stacktrace + "(" + file + ":" + line + ")"
-                      }
-                      exact = to_bool(value.@exact) ?? false
-                      location = string(value.@location) ?? ""
-                      version = string(value.@version) ?? ""
-                      if !is_empty(location) && !is_empty(version) {
-                        stacktrace = stacktrace + " "
-                        if !exact {
-                          stacktrace = stacktrace + "~"
-                        }
-                        stacktrace = stacktrace + "[" + location + ":" + version + "]"
-                      }
-                      stacktrace = stacktrace + "\n"
-                    }
-                    if stacktrace != "" {
-                      exception = exception + "\n" + stacktrace
-                    }
+                } else {
+                  .errors = push(.errors, "Instant invalid, trying property timeMillis instead: " + err)
+                }
+              }
+              if !tag_instant_valid {
+                epoch_milliseconds, err = to_int(event.@timeMillis)
+                if err == null && epoch_milliseconds != 0 {
+                  converted_timestamp, err = from_unix_timestamp(epoch_milliseconds, "milliseconds")
+                  if err == null {
+                    .timestamp = converted_timestamp
+                  } else {
+                    .errors = push(.errors, "timeMillis not parsable, using current time instead: " + err)
                   }
-
-                  message, err = string(event.Message)
-                  if err != null || is_empty(message) {
-                    message = null
-                    .errors = push(.errors, "Message not found.")
-                  }
-                  .message = join!(compact([message, exception]), "\n")
+                } else {
+                  .errors = push(.errors, "timeMillis not parsable, using current time instead: " + err)
                 }
               }
 
-          # Extends the processed files with the fields "container" and "file"
-          extended_logs_files:
-            inputs:
-              - processed_files_*
-            type: remap
-            source: |
-              del(.source_type)
-              if .errors == [] {
-                del(.errors)
+              .logger, err = string(event.@loggerName)
+              if err != null || is_empty(.logger) {
+                .errors = push(.errors, "Logger not found.")
               }
-              . |= parse_regex!(.file, r'^${LOG_DIR}/(?P<container>.*?)/(?P<file>.*?)$')
 
-          # Filters the logs of the Vector agent according to the defined log level
-          filtered_logs_vector:
-            inputs:
-              - vector
-            type: filter
-            condition: >
-              (.metadata.level == "TRACE" && "${VECTOR_FILE_LOG_LEVEL}" == "trace") ||
-              (.metadata.level == "DEBUG" && includes(["trace", "debug"], "${VECTOR_FILE_LOG_LEVEL}")) ||
-              (.metadata.level == "INFO" && includes(["trace", "debug", "info"], "${VECTOR_FILE_LOG_LEVEL}")) ||
-              (.metadata.level == "WARN" && includes(["trace", "debug", "info", "warn"], "${VECTOR_FILE_LOG_LEVEL}")) ||
-              (.metadata.level == "ERROR" && includes(["trace", "debug", "info", "warn", "error"], "${VECTOR_FILE_LOG_LEVEL}"))
-
-          # Aligns the logs of the Vector agent with the common format
-          extended_logs_vector:
-            inputs:
-              - filtered_logs_vector
-            type: remap
-            source: |
-              .container = "vector"
-              .level = .metadata.level
-              .logger = .metadata.module_path
-              if exists(.file) { .processed_file = del(.file) }
-              del(.metadata)
-              del(.pid)
-              del(.source_type)
-
-          # Add the fields "namespace", "cluster", "role" and "roleGroup" to all logs
-          extended_logs:
-            inputs:
-              - extended_logs_*
-            type: remap
-            source: |
-              .namespace = "${NAMESPACE}"
-              .cluster = "${CLUSTER_NAME}"
-              .role = "${ROLE_NAME}"
-              .roleGroup = "${ROLE_GROUP_NAME}"
-
-        sinks:
-          # Forward the logs to the Vector aggregator
-          aggregator:
-            inputs:
-              - extended_logs
-            type: vector
-            address: ${VECTOR_AGGREGATOR_ADDRESS}
-{% endif %}
-      YAMLEOF
-      )
-      actual=$(kubectl -n $NAMESPACE get cm spark-connect-server -o yaml | yq -o=json '.data')
-      expected_file=$(mktemp) && actual_file=$(mktemp)
-      printf '%s\n' "$expected" > "$expected_file"
-      printf '%s\n' "$actual" > "$actual_file"
-      if ! diff_out=$(diff -u "$expected_file" "$actual_file"); then
-        echo "ERROR: ConfigMap spark-connect-server data drifted from snapshot."
-        printf '%s\n' "$diff_out"
-        rm -f "$expected_file" "$actual_file"
-        exit 1
-      fi
-      rm -f "$expected_file" "$actual_file"
-  - script: |
-      expected=$(cat <<'YAMLEOF' | sed "s|__NAMESPACE__|$NAMESPACE|g" | yq -o=json
-      metrics.properties: |
-        *.sink.prometheusServlet.class=org.apache.spark.metrics.sink.PrometheusServlet
-        *.sink.prometheusServlet.path=/metrics/prometheus
-      security.properties: |
-        networkaddress.cache.negative.ttl=0
-        networkaddress.cache.ttl=30
-{% if lookup('env', 'VECTOR_AGGREGATOR') %}
-      vector.yaml: |
-        ---
-        data_dir: ${DATA_DIR}
-
-        log_schema:
-          host_key: pod
-
-        sources:
-          # Reads the internal Vector logs
-          vector:
-            type: internal_logs
-
-          files_stdout:
-            type: file
-            include:
-              - ${LOG_DIR}/*/*.stdout.log
-
-          files_stderr:
-            type: file
-            include:
-              - ${LOG_DIR}/*/*.stderr.log
-
-          files_log4j2:
-            type: file
-            include:
-              - ${LOG_DIR}/*/*.log4j2.xml
-            line_delimiter: "\r\n"
-
-        transforms:
-          processed_files_stdout:
-            inputs:
-              - files_stdout
-            type: remap
-            source: |
-              .logger = "ROOT"
-              .level = "INFO"
-
-          processed_files_stderr:
-            inputs:
-              - files_stderr
-            type: remap
-            source: |
-              .logger = "ROOT"
-              .level = "ERROR"
-
-          processed_files_log4j2:
-            inputs:
-              - files_log4j2
-            type: remap
-            source: |
-              raw_message = string!(.message)
-
-              .timestamp = now()
-              .logger = ""
-              .level = "INFO"
-              .message = ""
-              .errors = []
-
-              event = {}
-              parsed_event, err = parse_xml(raw_message)
+              level, err = string(event.@level)
               if err != null {
-                error = "XML not parsable: " + err
-                .errors = push(.errors, error)
-                log(error, level: "warn")
-                .message = raw_message
+                .errors = push(.errors, "Level not found, using \"" + .level + "\" instead.")
+              } else if !includes(["TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"], level) {
+                .errors = push(.errors, "Level \"" + level + "\" unknown, using \"" + .level + "\" instead.")
               } else {
-                if !is_object(parsed_event.Event) {
-                  error = "Parsed event contains no \"Event\" tag."
-                  .errors = push(.errors, error)
-                  log(error, level: "warn")
-                  .message = raw_message
-                } else {
-                  event = object!(parsed_event.Event)
+                .level = level
+              }
 
-                  tag_instant_valid = false
-                  instant, err = object(event.Instant)
-                  if err == null {
-                    epoch_nanoseconds, err = to_int(instant.@epochSecond) * 1_000_000_000 + to_int(instant.@nanoOfSecond)
-                    if err == null && epoch_nanoseconds != 0 {
-                      converted_timestamp, err = from_unix_timestamp(epoch_nanoseconds, "nanoseconds")
-                      if err == null {
-                        .timestamp = converted_timestamp
-                        tag_instant_valid = true
-                      } else {
-                        .errors = push(.errors, "Instant invalid, trying property timeMillis instead: " + err)
-                      }
-                    } else {
-                      .errors = push(.errors, "Instant invalid, trying property timeMillis instead: " + err)
-                    }
+              exception = null
+              thrown = event.Thrown
+              if is_object(thrown) {
+                exception = "Exception"
+                thread, err = string(event.@thread)
+                if err == null && !is_empty(thread) {
+                  exception = exception + " in thread \"" + thread + "\""
+                }
+                thrown_name, err = string(thrown.@name)
+                if err == null && !is_empty(exception) {
+                  exception = exception + " " + thrown_name
+                }
+                message = string(thrown.@localizedMessage) ??
+                  string(thrown.@message) ??
+                  ""
+                if !is_empty(message) {
+                  exception = exception + ": " + message
+                }
+                stacktrace_items = array(thrown.ExtendedStackTrace.ExtendedStackTraceItem) ?? []
+                stacktrace = ""
+                for_each(stacktrace_items) -> |_index, value| {
+                  stacktrace = stacktrace + "        "
+                  class = string(value.@class) ?? ""
+                  method = string(value.@method) ?? ""
+                  if !is_empty(class) && !is_empty(method) {
+                    stacktrace = stacktrace + "at " + class + "." + method
                   }
-                  if !tag_instant_valid {
-                    epoch_milliseconds, err = to_int(event.@timeMillis)
-                    if err == null && epoch_milliseconds != 0 {
-                      converted_timestamp, err = from_unix_timestamp(epoch_milliseconds, "milliseconds")
-                      if err == null {
-                        .timestamp = converted_timestamp
-                      } else {
-                        .errors = push(.errors, "timeMillis not parsable, using current time instead: " + err)
-                      }
-                    } else {
-                      .errors = push(.errors, "timeMillis not parsable, using current time instead: " + err)
-                    }
+                  file = string(value.@file) ?? ""
+                  line = string(value.@line) ?? ""
+                  if !is_empty(file) && !is_empty(line) {
+                    stacktrace = stacktrace + "(" + file + ":" + line + ")"
                   }
-
-                  .logger, err = string(event.@loggerName)
-                  if err != null || is_empty(.logger) {
-                    .errors = push(.errors, "Logger not found.")
+                  exact = to_bool(value.@exact) ?? false
+                  location = string(value.@location) ?? ""
+                  version = string(value.@version) ?? ""
+                  if !is_empty(location) && !is_empty(version) {
+                    stacktrace = stacktrace + " "
+                    if !exact {
+                      stacktrace = stacktrace + "~"
+                    }
+                    stacktrace = stacktrace + "[" + location + ":" + version + "]"
                   }
-
-                  level, err = string(event.@level)
-                  if err != null {
-                    .errors = push(.errors, "Level not found, using \"" + .level + "\" instead.")
-                  } else if !includes(["TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"], level) {
-                    .errors = push(.errors, "Level \"" + level + "\" unknown, using \"" + .level + "\" instead.")
-                  } else {
-                    .level = level
-                  }
-
-                  exception = null
-                  thrown = event.Thrown
-                  if is_object(thrown) {
-                    exception = "Exception"
-                    thread, err = string(event.@thread)
-                    if err == null && !is_empty(thread) {
-                      exception = exception + " in thread \"" + thread + "\""
-                    }
-                    thrown_name, err = string(thrown.@name)
-                    if err == null && !is_empty(exception) {
-                      exception = exception + " " + thrown_name
-                    }
-                    message = string(thrown.@localizedMessage) ??
-                      string(thrown.@message) ??
-                      ""
-                    if !is_empty(message) {
-                      exception = exception + ": " + message
-                    }
-                    stacktrace_items = array(thrown.ExtendedStackTrace.ExtendedStackTraceItem) ?? []
-                    stacktrace = ""
-                    for_each(stacktrace_items) -> |_index, value| {
-                      stacktrace = stacktrace + "        "
-                      class = string(value.@class) ?? ""
-                      method = string(value.@method) ?? ""
-                      if !is_empty(class) && !is_empty(method) {
-                        stacktrace = stacktrace + "at " + class + "." + method
-                      }
-                      file = string(value.@file) ?? ""
-                      line = string(value.@line) ?? ""
-                      if !is_empty(file) && !is_empty(line) {
-                        stacktrace = stacktrace + "(" + file + ":" + line + ")"
-                      }
-                      exact = to_bool(value.@exact) ?? false
-                      location = string(value.@location) ?? ""
-                      version = string(value.@version) ?? ""
-                      if !is_empty(location) && !is_empty(version) {
-                        stacktrace = stacktrace + " "
-                        if !exact {
-                          stacktrace = stacktrace + "~"
-                        }
-                        stacktrace = stacktrace + "[" + location + ":" + version + "]"
-                      }
-                      stacktrace = stacktrace + "\n"
-                    }
-                    if stacktrace != "" {
-                      exception = exception + "\n" + stacktrace
-                    }
-                  }
-
-                  message, err = string(event.Message)
-                  if err != null || is_empty(message) {
-                    message = null
-                    .errors = push(.errors, "Message not found.")
-                  }
-                  .message = join!(compact([message, exception]), "\n")
+                  stacktrace = stacktrace + "\n"
+                }
+                if stacktrace != "" {
+                  exception = exception + "\n" + stacktrace
                 }
               }
 
-          # Extends the processed files with the fields "container" and "file"
-          extended_logs_files:
-            inputs:
-              - processed_files_*
-            type: remap
-            source: |
-              del(.source_type)
-              if .errors == [] {
-                del(.errors)
+              message, err = string(event.Message)
+              if err != null || is_empty(message) {
+                message = null
+                .errors = push(.errors, "Message not found.")
               }
-              . |= parse_regex!(.file, r'^${LOG_DIR}/(?P<container>.*?)/(?P<file>.*?)$')
+              .message = join!(compact([message, exception]), "\n")
+            }
+          }
 
-          # Filters the logs of the Vector agent according to the defined log level
-          filtered_logs_vector:
-            inputs:
-              - vector
-            type: filter
-            condition: >
-              (.metadata.level == "TRACE" && "${VECTOR_FILE_LOG_LEVEL}" == "trace") ||
-              (.metadata.level == "DEBUG" && includes(["trace", "debug"], "${VECTOR_FILE_LOG_LEVEL}")) ||
-              (.metadata.level == "INFO" && includes(["trace", "debug", "info"], "${VECTOR_FILE_LOG_LEVEL}")) ||
-              (.metadata.level == "WARN" && includes(["trace", "debug", "info", "warn"], "${VECTOR_FILE_LOG_LEVEL}")) ||
-              (.metadata.level == "ERROR" && includes(["trace", "debug", "info", "warn", "error"], "${VECTOR_FILE_LOG_LEVEL}"))
+      # Extends the processed files with the fields "container" and "file"
+      extended_logs_files:
+        inputs:
+          - processed_files_*
+        type: remap
+        source: |
+          del(.source_type)
+          if .errors == [] {
+            del(.errors)
+          }
+          . |= parse_regex!(.file, r'^${LOG_DIR}/(?P<container>.*?)/(?P<file>.*?)$')
 
-          # Aligns the logs of the Vector agent with the common format
-          extended_logs_vector:
-            inputs:
-              - filtered_logs_vector
-            type: remap
-            source: |
-              .container = "vector"
-              .level = .metadata.level
-              .logger = .metadata.module_path
-              if exists(.file) { .processed_file = del(.file) }
-              del(.metadata)
-              del(.pid)
-              del(.source_type)
+      # Filters the logs of the Vector agent according to the defined log level
+      filtered_logs_vector:
+        inputs:
+          - vector
+        type: filter
+        condition: >
+          (.metadata.level == "TRACE" && "${VECTOR_FILE_LOG_LEVEL}" == "trace") ||
+          (.metadata.level == "DEBUG" && includes(["trace", "debug"], "${VECTOR_FILE_LOG_LEVEL}")) ||
+          (.metadata.level == "INFO" && includes(["trace", "debug", "info"], "${VECTOR_FILE_LOG_LEVEL}")) ||
+          (.metadata.level == "WARN" && includes(["trace", "debug", "info", "warn"], "${VECTOR_FILE_LOG_LEVEL}")) ||
+          (.metadata.level == "ERROR" && includes(["trace", "debug", "info", "warn", "error"], "${VECTOR_FILE_LOG_LEVEL}"))
 
-          # Add the fields "namespace", "cluster", "role" and "roleGroup" to all logs
-          extended_logs:
-            inputs:
-              - extended_logs_*
-            type: remap
-            source: |
-              .namespace = "${NAMESPACE}"
-              .cluster = "${CLUSTER_NAME}"
-              .role = "${ROLE_NAME}"
-              .roleGroup = "${ROLE_GROUP_NAME}"
+      # Aligns the logs of the Vector agent with the common format
+      extended_logs_vector:
+        inputs:
+          - filtered_logs_vector
+        type: remap
+        source: |
+          .container = "vector"
+          .level = .metadata.level
+          .logger = .metadata.module_path
+          if exists(.file) { .processed_file = del(.file) }
+          del(.metadata)
+          del(.pid)
+          del(.source_type)
 
-        sinks:
-          # Forward the logs to the Vector aggregator
-          aggregator:
-            inputs:
-              - extended_logs
-            type: vector
-            address: ${VECTOR_AGGREGATOR_ADDRESS}
+      # Add the fields "namespace", "cluster", "role" and "roleGroup" to all logs
+      extended_logs:
+        inputs:
+          - extended_logs_*
+        type: remap
+        source: |
+          .namespace = "${NAMESPACE}"
+          .cluster = "${CLUSTER_NAME}"
+          .role = "${ROLE_NAME}"
+          .roleGroup = "${ROLE_GROUP_NAME}"
+
+    sinks:
+      # Forward the logs to the Vector aggregator
+      aggregator:
+        inputs:
+          - extended_logs
+        type: vector
+        address: ${VECTOR_AGGREGATOR_ADDRESS}
 {% endif %}
-      YAMLEOF
-      )
-      actual=$(kubectl -n $NAMESPACE get cm spark-connect-executor -o yaml | yq -o=json '.data')
-      expected_file=$(mktemp) && actual_file=$(mktemp)
-      printf '%s\n' "$expected" > "$expected_file"
-      printf '%s\n' "$actual" > "$actual_file"
-      if ! diff_out=$(diff -u "$expected_file" "$actual_file"); then
-        echo "ERROR: ConfigMap spark-connect-executor data drifted from snapshot."
-        printf '%s\n' "$diff_out"
-        rm -f "$expected_file" "$actual_file"
-        exit 1
-      fi
-      rm -f "$expected_file" "$actual_file"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spark-connect-executor
+data:
+  metrics.properties: |
+    *.sink.prometheusServlet.class=org.apache.spark.metrics.sink.PrometheusServlet
+    *.sink.prometheusServlet.path=/metrics/prometheus
+  security.properties: |
+    networkaddress.cache.negative.ttl=0
+    networkaddress.cache.ttl=30
+{% if lookup('env', 'VECTOR_AGGREGATOR') %}
+  vector.yaml: |
+    ---
+    data_dir: ${DATA_DIR}
+
+    log_schema:
+      host_key: pod
+
+    sources:
+      # Reads the internal Vector logs
+      vector:
+        type: internal_logs
+
+      files_stdout:
+        type: file
+        include:
+          - ${LOG_DIR}/*/*.stdout.log
+
+      files_stderr:
+        type: file
+        include:
+          - ${LOG_DIR}/*/*.stderr.log
+
+      files_log4j2:
+        type: file
+        include:
+          - ${LOG_DIR}/*/*.log4j2.xml
+        line_delimiter: "\r\n"
+
+    transforms:
+      processed_files_stdout:
+        inputs:
+          - files_stdout
+        type: remap
+        source: |
+          .logger = "ROOT"
+          .level = "INFO"
+
+      processed_files_stderr:
+        inputs:
+          - files_stderr
+        type: remap
+        source: |
+          .logger = "ROOT"
+          .level = "ERROR"
+
+      processed_files_log4j2:
+        inputs:
+          - files_log4j2
+        type: remap
+        source: |
+          raw_message = string!(.message)
+
+          .timestamp = now()
+          .logger = ""
+          .level = "INFO"
+          .message = ""
+          .errors = []
+
+          event = {}
+          parsed_event, err = parse_xml(raw_message)
+          if err != null {
+            error = "XML not parsable: " + err
+            .errors = push(.errors, error)
+            log(error, level: "warn")
+            .message = raw_message
+          } else {
+            if !is_object(parsed_event.Event) {
+              error = "Parsed event contains no \"Event\" tag."
+              .errors = push(.errors, error)
+              log(error, level: "warn")
+              .message = raw_message
+            } else {
+              event = object!(parsed_event.Event)
+
+              tag_instant_valid = false
+              instant, err = object(event.Instant)
+              if err == null {
+                epoch_nanoseconds, err = to_int(instant.@epochSecond) * 1_000_000_000 + to_int(instant.@nanoOfSecond)
+                if err == null && epoch_nanoseconds != 0 {
+                  converted_timestamp, err = from_unix_timestamp(epoch_nanoseconds, "nanoseconds")
+                  if err == null {
+                    .timestamp = converted_timestamp
+                    tag_instant_valid = true
+                  } else {
+                    .errors = push(.errors, "Instant invalid, trying property timeMillis instead: " + err)
+                  }
+                } else {
+                  .errors = push(.errors, "Instant invalid, trying property timeMillis instead: " + err)
+                }
+              }
+              if !tag_instant_valid {
+                epoch_milliseconds, err = to_int(event.@timeMillis)
+                if err == null && epoch_milliseconds != 0 {
+                  converted_timestamp, err = from_unix_timestamp(epoch_milliseconds, "milliseconds")
+                  if err == null {
+                    .timestamp = converted_timestamp
+                  } else {
+                    .errors = push(.errors, "timeMillis not parsable, using current time instead: " + err)
+                  }
+                } else {
+                  .errors = push(.errors, "timeMillis not parsable, using current time instead: " + err)
+                }
+              }
+
+              .logger, err = string(event.@loggerName)
+              if err != null || is_empty(.logger) {
+                .errors = push(.errors, "Logger not found.")
+              }
+
+              level, err = string(event.@level)
+              if err != null {
+                .errors = push(.errors, "Level not found, using \"" + .level + "\" instead.")
+              } else if !includes(["TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"], level) {
+                .errors = push(.errors, "Level \"" + level + "\" unknown, using \"" + .level + "\" instead.")
+              } else {
+                .level = level
+              }
+
+              exception = null
+              thrown = event.Thrown
+              if is_object(thrown) {
+                exception = "Exception"
+                thread, err = string(event.@thread)
+                if err == null && !is_empty(thread) {
+                  exception = exception + " in thread \"" + thread + "\""
+                }
+                thrown_name, err = string(thrown.@name)
+                if err == null && !is_empty(exception) {
+                  exception = exception + " " + thrown_name
+                }
+                message = string(thrown.@localizedMessage) ??
+                  string(thrown.@message) ??
+                  ""
+                if !is_empty(message) {
+                  exception = exception + ": " + message
+                }
+                stacktrace_items = array(thrown.ExtendedStackTrace.ExtendedStackTraceItem) ?? []
+                stacktrace = ""
+                for_each(stacktrace_items) -> |_index, value| {
+                  stacktrace = stacktrace + "        "
+                  class = string(value.@class) ?? ""
+                  method = string(value.@method) ?? ""
+                  if !is_empty(class) && !is_empty(method) {
+                    stacktrace = stacktrace + "at " + class + "." + method
+                  }
+                  file = string(value.@file) ?? ""
+                  line = string(value.@line) ?? ""
+                  if !is_empty(file) && !is_empty(line) {
+                    stacktrace = stacktrace + "(" + file + ":" + line + ")"
+                  }
+                  exact = to_bool(value.@exact) ?? false
+                  location = string(value.@location) ?? ""
+                  version = string(value.@version) ?? ""
+                  if !is_empty(location) && !is_empty(version) {
+                    stacktrace = stacktrace + " "
+                    if !exact {
+                      stacktrace = stacktrace + "~"
+                    }
+                    stacktrace = stacktrace + "[" + location + ":" + version + "]"
+                  }
+                  stacktrace = stacktrace + "\n"
+                }
+                if stacktrace != "" {
+                  exception = exception + "\n" + stacktrace
+                }
+              }
+
+              message, err = string(event.Message)
+              if err != null || is_empty(message) {
+                message = null
+                .errors = push(.errors, "Message not found.")
+              }
+              .message = join!(compact([message, exception]), "\n")
+            }
+          }
+
+      # Extends the processed files with the fields "container" and "file"
+      extended_logs_files:
+        inputs:
+          - processed_files_*
+        type: remap
+        source: |
+          del(.source_type)
+          if .errors == [] {
+            del(.errors)
+          }
+          . |= parse_regex!(.file, r'^${LOG_DIR}/(?P<container>.*?)/(?P<file>.*?)$')
+
+      # Filters the logs of the Vector agent according to the defined log level
+      filtered_logs_vector:
+        inputs:
+          - vector
+        type: filter
+        condition: >
+          (.metadata.level == "TRACE" && "${VECTOR_FILE_LOG_LEVEL}" == "trace") ||
+          (.metadata.level == "DEBUG" && includes(["trace", "debug"], "${VECTOR_FILE_LOG_LEVEL}")) ||
+          (.metadata.level == "INFO" && includes(["trace", "debug", "info"], "${VECTOR_FILE_LOG_LEVEL}")) ||
+          (.metadata.level == "WARN" && includes(["trace", "debug", "info", "warn"], "${VECTOR_FILE_LOG_LEVEL}")) ||
+          (.metadata.level == "ERROR" && includes(["trace", "debug", "info", "warn", "error"], "${VECTOR_FILE_LOG_LEVEL}"))
+
+      # Aligns the logs of the Vector agent with the common format
+      extended_logs_vector:
+        inputs:
+          - filtered_logs_vector
+        type: remap
+        source: |
+          .container = "vector"
+          .level = .metadata.level
+          .logger = .metadata.module_path
+          if exists(.file) { .processed_file = del(.file) }
+          del(.metadata)
+          del(.pid)
+          del(.source_type)
+
+      # Add the fields "namespace", "cluster", "role" and "roleGroup" to all logs
+      extended_logs:
+        inputs:
+          - extended_logs_*
+        type: remap
+        source: |
+          .namespace = "${NAMESPACE}"
+          .cluster = "${CLUSTER_NAME}"
+          .role = "${ROLE_NAME}"
+          .roleGroup = "${ROLE_GROUP_NAME}"
+
+    sinks:
+      # Forward the logs to the Vector aggregator
+      aggregator:
+        inputs:
+          - extended_logs
+        type: vector
+        address: ${VECTOR_AGGREGATOR_ADDRESS}
+{% endif %}

--- a/tests/templates/kuttl/spark-connect/14-assert.yaml.j2
+++ b/tests/templates/kuttl/spark-connect/14-assert.yaml.j2
@@ -1,0 +1,228 @@
+---
+# Snapshot assert for the executor Pod that Spark Connect created.
+# The `template.yaml` entry in the ConfigMap value cannot be asserted declaratively.
+#
+# kuttl mechanics that shape this file:
+#
+#  * Spark names executor pods `<server>-<hash>-exec-N`, so there is no
+#    deterministic `metadata.name`. Omitting the name makes kuttl use
+#    `metadata.labels` as a label selector, and it then passes if ANY listed Pod
+#    is a subset match -- hence `status.phase: Running`, so a terminating
+#    executor from an earlier reconcile cannot produce a false pass.
+#  * kuttl requires every array to have the SAME LENGTH as the live object and
+#    compares arrays positionally (`IsSubset` -> "slice length mismatch"). Every
+#    container, volume and volumeMount below must therefore be listed, including
+#    the ones Spark and Kubernetes inject. Array *elements* are maps and are
+#    subset-matched, so volatile fields inside an element are simply omitted;
+#    each such omission is called out inline.
+#  * Live container order is [vector, spark] -- the reverse of the template.
+#    Spark extracts the container named by
+#    `spark.kubernetes.executor.podTemplateContainerName` and re-appends it last.
+#
+# Deliberately not asserted:
+#  * every container `image` -- the reason the ConfigMap snapshot was dropped.
+#  * `containers[spark].env` -- Spark injects ~40 variables and emits
+#    `SPARK_JAVA_OPT_*` in a different order on every run, so a positional
+#    comparison can never pass reliably.
+#  * `containers[spark].args` / `.ports` -- Spark-owned, would couple this assert
+#    to the Spark version for no operator coverage.
+#  * `app.kubernetes.io/version` (changes on a release build) and the `spark-*`
+#    labels carrying generated ids.
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  # No name on purpose: these labels are the selector (see header).
+  labels:
+    app.kubernetes.io/component: executor
+    app.kubernetes.io/instance: spark-connect
+    app.kubernetes.io/managed-by: spark.stackable.tech_connect
+    app.kubernetes.io/name: spark-connect
+    app.kubernetes.io/role-group: default
+    spark-role: executor
+    stackable.tech/vendor: Stackable
+spec:
+  # Comes from spark.kubernetes.authenticate.driver.serviceAccountName; the
+  # operator's pod template does not set it.
+  serviceAccountName: spark-connect-serviceaccount
+  enableServiceLinks: false
+  securityContext:
+    # Required so the spark container can read the truststore the init container
+    # writes into the shared emptyDir.
+    fsGroup: 1000
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: executor
+                app.kubernetes.io/instance: spark-connect
+                app.kubernetes.io/name: spark-connect
+            topologyKey: kubernetes.io/hostname
+          weight: 70
+  containers:
+{% if lookup('env', 'VECTOR_AGGREGATOR') %}
+    # Spark passes non-primary template containers through untouched.
+    - name: vector
+      command:
+        - /bin/bash
+        - -x
+        - -euo
+        - pipefail
+        - -c
+      env:
+        - name: CLUSTER_NAME
+          value: spark-connect
+        - name: DATA_DIR
+          value: /stackable/log/_vector-state
+        - name: LOG_DIR
+          value: /stackable/log
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: ROLE_GROUP_NAME
+          value: default
+        - name: ROLE_NAME
+          value: executor
+        - name: VECTOR_AGGREGATOR_ADDRESS
+          valueFrom:
+            configMapKeyRef:
+              key: ADDRESS
+              name: vector-aggregator-discovery
+        - name: VECTOR_CONFIG_YAML
+          value: /stackable/config/vector.yaml
+        - name: VECTOR_FILE_LOG_LEVEL
+          value: info
+        - name: VECTOR_LOG
+          value: info
+      resources:
+        limits:
+          cpu: 500m
+          memory: 128Mi
+        requests:
+          cpu: 250m
+          memory: 128Mi
+      volumeMounts:
+        - name: config
+          mountPath: /stackable/config/vector.yaml
+          subPath: vector.yaml
+          readOnly: true
+        - name: log
+          mountPath: /stackable/log
+        # name is kube-api-access-<random>, injected by Kubernetes
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+{% endif %}
+    - name: spark
+      resources:
+        # Set by Spark from spark.executor.* -- 1024M plus the 1m
+        # memoryOverhead the test scenario overrides.
+        limits:
+          cpu: "1"
+          memory: 1025Mi
+        requests:
+          cpu: "1"
+          memory: 1025Mi
+      volumeMounts:
+        - name: config
+          mountPath: /stackable/spark/conf
+        - name: log
+          mountPath: /stackable/log
+        - name: minio-credentials-class-s3-credentials
+          mountPath: /stackable/secrets/minio-credentials-class
+{% if test_scenario['values']['s3-use-tls'] == 'true' %}
+        - name: minio-tls-ca-ca-cert
+          mountPath: /stackable/secrets/minio-tls-ca
+{% endif %}
+        - name: stackable-truststore
+          mountPath: /stackable/truststore
+        - name: log-config
+          mountPath: /stackable/log_config
+        - name: spark-conf-volume-exec
+          mountPath: /opt/spark/conf
+        # mountPath is /var/data/spark-<uuid>, generated per run
+        - name: spark-local-dir-1
+        # name is kube-api-access-<random>, injected by Kubernetes
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+{% if test_scenario['values']['s3-use-tls'] == 'true' %}
+  initContainers:
+    - name: tls-truststore-init
+      command:
+        - /bin/bash
+        - -x
+        - -euo
+        - pipefail
+        - -c
+        - cert-tools generate-pkcs12-truststore --pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem --out /stackable/truststore/truststore.p12 --out-password changeit && cert-tools generate-pkcs12-truststore --out /stackable/truststore/truststore.p12 --out-password changeit --pkcs12 /stackable/truststore/truststore.p12:changeit --pem /stackable/secrets/minio-tls-ca/ca.crt
+      resources:
+        limits:
+          cpu: 10m
+          memory: 128Mi
+        requests:
+          cpu: 10m
+          memory: 128Mi
+      volumeMounts:
+        - name: minio-credentials-class-s3-credentials
+          mountPath: /stackable/secrets/minio-credentials-class
+        - name: minio-tls-ca-ca-cert
+          mountPath: /stackable/secrets/minio-tls-ca
+        - name: stackable-truststore
+          mountPath: /stackable/truststore
+        # name is kube-api-access-<random>, injected by Kubernetes
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+{% endif %}
+  volumes:
+    - name: log
+      emptyDir:
+        sizeLimit: 30Mi
+    - name: config
+      configMap:
+        name: spark-connect-executor
+    - name: minio-credentials-class-s3-credentials
+      ephemeral:
+        volumeClaimTemplate:
+          metadata:
+            annotations:
+              secrets.stackable.tech/class: minio-credentials-class
+              secrets.stackable.tech/provision-parts: public-private
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: "1"
+            storageClassName: secrets.stackable.tech
+{% if test_scenario['values']['s3-use-tls'] == 'true' %}
+    - name: minio-tls-ca-ca-cert
+      ephemeral:
+        volumeClaimTemplate:
+          metadata:
+            annotations:
+              secrets.stackable.tech/class: minio-tls-ca
+              secrets.stackable.tech/provision-parts: public
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: "1"
+            storageClassName: secrets.stackable.tech
+{% endif %}
+    - name: stackable-truststore
+      emptyDir: {}
+    - name: log-config
+      configMap:
+        name: spark-connect-log-config
+    # configMap.name is spark-exec-<hash>-conf-map, generated per run
+    - name: spark-conf-volume-exec
+    - name: spark-local-dir-1
+      emptyDir: {}
+    # name is kube-api-access-<random>, injected by Kubernetes
+    - projected:
+        defaultMode: 420
+status:
+  phase: Running


### PR DESCRIPTION
## Description

Backports https://github.com/stackabletech/spark-k8s-operator/pull/733 into 26.7

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
