### PR TITLE
feat: Enable restarter-controller for history and connect server StatefulSets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- The history server and Spark Connect server StatefulSets now carry the
+  `restarter.stackable.tech/enabled: "true"` label, opting them into the restarter-controller so
+  that their Pods are automatically rolled when a mounted ConfigMap or Secret changes ([#754]).
+
 ### Changed
 
 - Internal operator refactoring: introduce a build() step in the history and connect
@@ -46,6 +52,7 @@ All notable changes to this project will be documented in this file.
 [#745]: https://github.com/stackabletech/spark-k8s-operator/pull/745
 [#746]: https://github.com/stackabletech/spark-k8s-operator/pull/746
 [#753]: https://github.com/stackabletech/spark-k8s-operator/pull/753
+[#754]: https://github.com/stackabletech/spark-k8s-operator/pull/754
 
 ## [26.7.0] - 2026-07-21
 

--- a/rust/operator-binary/src/connect/controller/build/server.rs
+++ b/rust/operator-binary/src/connect/controller/build/server.rs
@@ -16,6 +16,7 @@ use stackable_operator::{
             },
         },
     },
+    constants::RESTART_CONTROLLER_ENABLED_LABEL,
     crd::listener,
     k8s_openapi::{
         DeepMerge,
@@ -324,6 +325,9 @@ pub(crate) fn build_stateful_set(
             object_name(&validated.name_any(), SparkConnectRole::Server),
             SparkConnectRole::Server,
         )
+        // Opt into the restarter-controller: it rolls the StatefulSet's Pods when a mounted
+        // ConfigMap or Secret changes. See stackabletech/issues#816.
+        .with_label(RESTART_CONTROLLER_ENABLED_LABEL.to_owned())
         .build(),
         spec: Some(StatefulSetSpec {
             template: pod_template,

--- a/rust/operator-binary/src/history/controller/build/resource/statefulset.rs
+++ b/rust/operator-binary/src/history/controller/build/resource/statefulset.rs
@@ -7,6 +7,7 @@ use stackable_operator::{
         pod::{PodBuilder, security::PodSecurityContextBuilder, volume::VolumeBuilder},
     },
     constant,
+    constants::RESTART_CONTROLLER_ENABLED_LABEL,
     k8s_openapi::{
         DeepMerge,
         api::apps::v1::{StatefulSet, StatefulSetSpec},
@@ -247,6 +248,9 @@ pub(crate) fn build_stateful_set(
         resource_names.stateful_set_name().to_string(),
         role_group_name,
     )
+    // Opt into the restarter-controller: it rolls the StatefulSet's Pods when a mounted
+    // ConfigMap or Secret changes. See stackabletech/issues#816.
+    .with_label(RESTART_CONTROLLER_ENABLED_LABEL.to_owned())
     .build();
 
     Ok(StatefulSet {

--- a/tests/templates/kuttl/spark-connect-kerberos/12-assert.yaml
+++ b/tests/templates/kuttl/spark-connect-kerberos/12-assert.yaml
@@ -7,11 +7,14 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: spark-connect-server
+  # generation stays at 1: the restarter-controller label must not itself trigger a rollout.
+  generation: 1
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: spark-connect
     app.kubernetes.io/managed-by: spark.stackable.tech_connect
     app.kubernetes.io/name: spark-connect
+    restarter.stackable.tech/enabled: "true"
     stackable.tech/vendor: Stackable
   ownerReferences:
     - apiVersion: spark.stackable.tech/v1alpha1

--- a/tests/templates/kuttl/spark-connect/12-assert.yaml
+++ b/tests/templates/kuttl/spark-connect/12-assert.yaml
@@ -7,11 +7,14 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: spark-connect-server
+  # generation stays at 1: the restarter-controller label must not itself trigger a rollout.
+  generation: 1
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: spark-connect
     app.kubernetes.io/managed-by: spark.stackable.tech_connect
     app.kubernetes.io/name: spark-connect
+    restarter.stackable.tech/enabled: "true"
     stackable.tech/vendor: Stackable
   ownerReferences:
     - apiVersion: spark.stackable.tech/v1alpha1

--- a/tests/templates/kuttl/spark-history-server/06-assert.yaml
+++ b/tests/templates/kuttl/spark-history-server/06-assert.yaml
@@ -7,6 +7,10 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: spark-history-node-default
+  # generation stays at 1: the restarter-controller label must not itself trigger a rollout.
+  generation: 1
+  labels:
+    restarter.stackable.tech/enabled: "true"
 status:
   readyReplicas: 1
 ---


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/issues/issues/816

Connect test:

```
--- PASS: kuttl (673.98s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/spark-connect_openshift-false_iceberg-latest-1.11.0_hive-iceberg-4.0.0_spark-connect-4.1.2_s3-use-tls-true (673.96s)
PASS
```

History test:

```
--- PASS: kuttl (173.41s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/spark-history-server_openshift-false_spark-4.1.2_s3-use-tls-true (173.39s)
PASS
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
