### PR TITLE
fix: Add missing owns/watches and test early-exit reconcile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ All notable changes to this project will be documented in this file.
   labels without the version label, so that the labels stay stable across upgrades.
   Existing connect and history-server StatefulSets must be deleted once before the new operator
   can reconcile them (connect server: [#750], history server: [#753]).
+- The history and connect controllers now watch all resources that they create, the missing RBAC
+  `watch` permissions were added, and all controllers early-exit the reconcile action when the object
+  is marked for deletion ([#757]).
 
 [#721]: https://github.com/stackabletech/spark-k8s-operator/pull/721
 [#727]: https://github.com/stackabletech/spark-k8s-operator/pull/727
@@ -58,6 +61,7 @@ All notable changes to this project will be documented in this file.
 [#750]: https://github.com/stackabletech/spark-k8s-operator/pull/750
 [#753]: https://github.com/stackabletech/spark-k8s-operator/pull/753
 [#754]: https://github.com/stackabletech/spark-k8s-operator/pull/754
+[#757]: https://github.com/stackabletech/spark-k8s-operator/pull/757
 
 ## [26.7.0] - 2026-07-21
 

--- a/deploy/helm/spark-k8s-operator/templates/roles.yaml
+++ b/deploy/helm/spark-k8s-operator/templates/roles.yaml
@@ -26,47 +26,27 @@ rules:
       - get
       - list
       - watch
-  # ConfigMaps hold pod templates and Spark configuration. All three controllers apply
-  # them via Server-Side Apply (create + patch). The history and connect controllers
-  # track them for orphan cleanup (list + delete). All controllers watch ConfigMaps via
-  # .owns(ConfigMap) so that changes trigger re-reconciliation.
-  # get is required for the ReconciliationPaused strategy in cluster_resources.add().
   - apiGroups:
       - ""
     resources:
+      # ConfigMaps hold pod templates and Spark configuration. All three controllers apply
+      # them via Server-Side Apply (create + patch). The history and connect controllers
+      # track them for orphan cleanup (list + delete). All controllers watch ConfigMaps via
+      # .owns(ConfigMap) so that changes trigger re-reconciliation.
+      # get is required for the ReconciliationPaused strategy in cluster_resources.add().
       - configmaps
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - watch
-  # Services expose Spark History Server and Spark Connect Server for metrics and
-  # inter-component communication. Applied via Server-Side Apply and tracked for orphan
-  # cleanup by the history and connect controllers. The history and connect controllers
-  # watch Services via .owns(Service) to trigger re-reconciliation on change.
-  # get is required for the ReconciliationPaused strategy in cluster_resources.add().
-  - apiGroups:
-      - ""
-    resources:
-      - services
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - watch
-  # ServiceAccounts are created per SparkApplication (directly via client.apply_patch,
-  # referencing spark-k8s-clusterrole) and per SparkHistoryServer/SparkConnectServer
-  # (via cluster_resources.add). The history and connect controllers track them for
-  # orphan cleanup (list + delete) and watch them via .owns(ServiceAccount).
-  # get is required for the ReconciliationPaused strategy in cluster_resources.add().
-  - apiGroups:
-      - ""
-    resources:
+      # ServiceAccounts are created per SparkApplication (directly via client.apply_patch,
+      # referencing spark-k8s-clusterrole) and per SparkHistoryServer/SparkConnectServer
+      # (via cluster_resources.add). The history and connect controllers track them for
+      # orphan cleanup (list + delete) and watch them via .owns(ServiceAccount).
+      # get is required for the ReconciliationPaused strategy in cluster_resources.add().
       - serviceaccounts
+      # Services expose Spark History Server and Spark Connect Server for metrics and
+      # inter-component communication. Applied via Server-Side Apply and tracked for orphan
+      # cleanup by the history and connect controllers. The history and connect controllers
+      # watch Services via .owns(Service) to trigger re-reconciliation on change.
+      # get is required for the ReconciliationPaused strategy in cluster_resources.add().
+      - services
     verbs:
       - create
       - delete

--- a/deploy/helm/spark-k8s-operator/templates/roles.yaml
+++ b/deploy/helm/spark-k8s-operator/templates/roles.yaml
@@ -61,7 +61,7 @@ rules:
   # ServiceAccounts are created per SparkApplication (directly via client.apply_patch,
   # referencing spark-k8s-clusterrole) and per SparkHistoryServer/SparkConnectServer
   # (via cluster_resources.add). The history and connect controllers track them for
-  # orphan cleanup (list + delete). No controller watches ServiceAccounts via .owns().
+  # orphan cleanup (list + delete) and watch them via .owns(ServiceAccount).
   # get is required for the ReconciliationPaused strategy in cluster_resources.add().
   - apiGroups:
       - ""
@@ -73,11 +73,12 @@ rules:
       - get
       - list
       - patch
+      - watch
   # RoleBindings are created per SparkApplication (directly via client.apply_patch,
   # binding to spark-k8s-clusterrole) and per SparkHistoryServer/SparkConnectServer
   # (via cluster_resources.add, binding to their respective ClusterRoles). The history
-  # and connect controllers track them for orphan cleanup (list + delete).
-  # No controller watches RoleBindings via .owns().
+  # and connect controllers track them for orphan cleanup (list + delete) and watch
+  # them via .owns(RoleBinding).
   # get is required for the ReconciliationPaused strategy in cluster_resources.add().
   - apiGroups:
       - rbac.authorization.k8s.io
@@ -89,6 +90,7 @@ rules:
       - get
       - list
       - patch
+      - watch
   # Required to create RoleBindings that reference these ClusterRoles.
   - apiGroups:
       - rbac.authorization.k8s.io
@@ -127,8 +129,8 @@ rules:
       - create
       - patch
   # PodDisruptionBudgets limit voluntary disruptions to Spark History Server pods.
-  # Applied via Server-Side Apply and tracked for orphan cleanup by the history
-  # controller. No controller watches PDBs via .owns().
+  # Applied via Server-Side Apply, tracked for orphan cleanup by the history
+  # controller, which also watches them via .owns(PodDisruptionBudget).
   # get is required for the ReconciliationPaused strategy in cluster_resources.add().
   - apiGroups:
       - policy
@@ -140,6 +142,7 @@ rules:
       - get
       - list
       - patch
+      - watch
   # The operator can maintain its own CRDs, e.g. to update conversion webhook certificates.
   - apiGroups:
       - apiextensions.k8s.io
@@ -194,7 +197,8 @@ rules:
       - list
       - watch
   # Required for managing how the History Server and Connect Server are exposed
-  # outside of the cluster.
+  # outside of the cluster. The history and connect controllers watch Listeners via
+  # .owns(Listener).
   - apiGroups:
       - listeners.stackable.tech
     resources:
@@ -205,3 +209,4 @@ rules:
       - get
       - list
       - patch
+      - watch

--- a/rust/operator-binary/src/connect/controller.rs
+++ b/rust/operator-binary/src/connect/controller.rs
@@ -152,65 +152,26 @@ pub fn error_policy(
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
-    use stackable_operator::{
-        cli::OperatorEnvironmentOptions,
-        client::Client,
-        commons::networking::DomainName,
-        kube::{Client as KubeClient, Config},
-        utils::cluster_info::KubernetesClusterInfo,
-    };
+    use indoc::indoc;
 
     use super::*;
+    use crate::test_support::assert_reconcile_exits_early;
 
-    /// The client points at a closed port, so any API call would fail the reconciliation: an `Ok`
-    /// proves that a cluster being deleted returns before the reconciler touches the Kubernetes
-    /// API, and because the spec is invalid, before the [`DeserializeGuard`] is unwrapped.
+    /// A `SparkConnectServer` marked for deletion must be reconciled without any API call. The
+    /// invalid spec additionally pins the early return above the [`DeserializeGuard`] unwrap.
     #[test]
     fn reconcile_exits_early_for_deleted_cluster() {
-        let object = serde_yaml::from_str(
-            r#"
-apiVersion: spark.stackable.tech/v1alpha1
-kind: SparkConnectServer
-metadata:
-  name: spark-connect
-  namespace: default
-  deletionTimestamp: "2026-08-14T12:00:00Z"
-spec: {}
-"#,
-        )
-        .expect("YAML parses; the invalid spec is captured inside the DeserializeGuard");
-
-        let action = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("current-thread tokio runtime")
-            .block_on(async {
-                let ctx = Arc::new(Ctx {
-                    client: Client::new(
-                        KubeClient::try_from(Config::new(
-                            "http://127.0.0.1:1".parse().expect("valid static URI"),
-                        ))
-                        .expect("client from static config"),
-                        None,
-                        "default".to_owned(),
-                        KubernetesClusterInfo {
-                            cluster_domain: DomainName::from_str("cluster.local")
-                                .expect("valid cluster domain"),
-                        },
-                    ),
-                    operator_environment: OperatorEnvironmentOptions {
-                        operator_namespace: "stackable-operators".to_owned(),
-                        operator_service_name: "spark-k8s-operator".to_owned(),
-                        image_repository: "oci.stackable.tech/sdp".to_owned(),
-                    },
-                });
-
-                reconcile(Arc::new(object), ctx).await
-            })
-            .expect("a deleted cluster reconciles without any API call");
-
-        assert_eq!(action, Action::await_change());
+        assert_reconcile_exits_early(
+            indoc! {r#"
+                apiVersion: spark.stackable.tech/v1alpha1
+                kind: SparkConnectServer
+                metadata:
+                  name: spark-connect
+                  namespace: default
+                  deletionTimestamp: "2026-08-14T12:00:00Z"
+                spec: {}
+            "#},
+            reconcile,
+        );
     }
 }

--- a/rust/operator-binary/src/connect/controller.rs
+++ b/rust/operator-binary/src/connect/controller.rs
@@ -10,6 +10,7 @@ use stackable_operator::{
         rbac::v1::RoleBinding,
     },
     kube::{
+        Resource,
         core::{DeserializeGuard, error_boundary},
         runtime::controller::Action,
     },
@@ -91,6 +92,10 @@ pub async fn reconcile(
 ) -> Result<Action> {
     tracing::info!("Starting reconcile connect server");
 
+    if scs.meta().deletion_timestamp.is_some() {
+        return Ok(Action::await_change());
+    }
+
     let scs = scs
         .0
         .as_ref()
@@ -142,5 +147,70 @@ pub fn error_policy(
     match error {
         Error::InvalidSparkConnectServer { .. } => Action::await_change(),
         _ => Action::requeue(*Duration::from_secs(5)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use stackable_operator::{
+        cli::OperatorEnvironmentOptions,
+        client::Client,
+        commons::networking::DomainName,
+        kube::{Client as KubeClient, Config},
+        utils::cluster_info::KubernetesClusterInfo,
+    };
+
+    use super::*;
+
+    /// The client points at a closed port, so any API call would fail the reconciliation: an `Ok`
+    /// proves that a cluster being deleted returns before the reconciler touches the Kubernetes
+    /// API, and because the spec is invalid, before the [`DeserializeGuard`] is unwrapped.
+    #[test]
+    fn reconcile_exits_early_for_deleted_cluster() {
+        let object = serde_yaml::from_str(
+            r#"
+apiVersion: spark.stackable.tech/v1alpha1
+kind: SparkConnectServer
+metadata:
+  name: spark-connect
+  namespace: default
+  deletionTimestamp: "2026-08-14T12:00:00Z"
+spec: {}
+"#,
+        )
+        .expect("YAML parses; the invalid spec is captured inside the DeserializeGuard");
+
+        let action = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread tokio runtime")
+            .block_on(async {
+                let ctx = Arc::new(Ctx {
+                    client: Client::new(
+                        KubeClient::try_from(Config::new(
+                            "http://127.0.0.1:1".parse().expect("valid static URI"),
+                        ))
+                        .expect("client from static config"),
+                        None,
+                        "default".to_owned(),
+                        KubernetesClusterInfo {
+                            cluster_domain: DomainName::from_str("cluster.local")
+                                .expect("valid cluster domain"),
+                        },
+                    ),
+                    operator_environment: OperatorEnvironmentOptions {
+                        operator_namespace: "stackable-operators".to_owned(),
+                        operator_service_name: "spark-k8s-operator".to_owned(),
+                        image_repository: "oci.stackable.tech/sdp".to_owned(),
+                    },
+                });
+
+                reconcile(Arc::new(object), ctx).await
+            })
+            .expect("a deleted cluster reconciles without any API call");
+
+        assert_eq!(action, Action::await_change());
     }
 }

--- a/rust/operator-binary/src/history/controller.rs
+++ b/rust/operator-binary/src/history/controller.rs
@@ -132,65 +132,26 @@ pub fn error_policy(
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
-    use stackable_operator::{
-        cli::OperatorEnvironmentOptions,
-        client::Client,
-        commons::networking::DomainName,
-        kube::{Client as KubeClient, Config},
-        utils::cluster_info::KubernetesClusterInfo,
-    };
+    use indoc::indoc;
 
     use super::*;
+    use crate::test_support::assert_reconcile_exits_early;
 
-    /// The client points at a closed port, so any API call would fail the reconciliation: an `Ok`
-    /// proves that a cluster being deleted returns before the reconciler touches the Kubernetes
-    /// API, and because the spec is invalid, before the [`DeserializeGuard`] is unwrapped.
+    /// A `SparkHistoryServer` marked for deletion must be reconciled without any API call. The
+    /// invalid spec additionally pins the early return above the [`DeserializeGuard`] unwrap.
     #[test]
     fn reconcile_exits_early_for_deleted_cluster() {
-        let object = serde_yaml::from_str(
-            r#"
-apiVersion: spark.stackable.tech/v1alpha1
-kind: SparkHistoryServer
-metadata:
-  name: spark-history
-  namespace: default
-  deletionTimestamp: "2026-08-14T12:00:00Z"
-spec: {}
-"#,
-        )
-        .expect("YAML parses; the invalid spec is captured inside the DeserializeGuard");
-
-        let action = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("current-thread tokio runtime")
-            .block_on(async {
-                let ctx = Arc::new(Ctx {
-                    client: Client::new(
-                        KubeClient::try_from(Config::new(
-                            "http://127.0.0.1:1".parse().expect("valid static URI"),
-                        ))
-                        .expect("client from static config"),
-                        None,
-                        "default".to_owned(),
-                        KubernetesClusterInfo {
-                            cluster_domain: DomainName::from_str("cluster.local")
-                                .expect("valid cluster domain"),
-                        },
-                    ),
-                    operator_environment: OperatorEnvironmentOptions {
-                        operator_namespace: "stackable-operators".to_owned(),
-                        operator_service_name: "spark-k8s-operator".to_owned(),
-                        image_repository: "oci.stackable.tech/sdp".to_owned(),
-                    },
-                });
-
-                reconcile(Arc::new(object), ctx).await
-            })
-            .expect("a deleted cluster reconciles without any API call");
-
-        assert_eq!(action, Action::await_change());
+        assert_reconcile_exits_early(
+            indoc! {r#"
+                apiVersion: spark.stackable.tech/v1alpha1
+                kind: SparkHistoryServer
+                metadata:
+                  name: spark-history
+                  namespace: default
+                  deletionTimestamp: "2026-08-14T12:00:00Z"
+                spec: {}
+            "#},
+            reconcile,
+        );
     }
 }

--- a/rust/operator-binary/src/history/controller.rs
+++ b/rust/operator-binary/src/history/controller.rs
@@ -11,6 +11,7 @@ use stackable_operator::{
         rbac::v1::RoleBinding,
     },
     kube::{
+        Resource,
         core::{DeserializeGuard, error_boundary},
         runtime::controller::Action,
     },
@@ -84,6 +85,10 @@ pub async fn reconcile(
 ) -> Result<Action, Error> {
     tracing::info!("Starting reconcile history server");
 
+    if shs.meta().deletion_timestamp.is_some() {
+        return Ok(Action::await_change());
+    }
+
     let shs = shs
         .0
         .as_ref()
@@ -122,5 +127,70 @@ pub fn error_policy(
     match error {
         Error::InvalidSparkHistoryServer { .. } => Action::await_change(),
         _ => Action::requeue(*Duration::from_secs(5)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use stackable_operator::{
+        cli::OperatorEnvironmentOptions,
+        client::Client,
+        commons::networking::DomainName,
+        kube::{Client as KubeClient, Config},
+        utils::cluster_info::KubernetesClusterInfo,
+    };
+
+    use super::*;
+
+    /// The client points at a closed port, so any API call would fail the reconciliation: an `Ok`
+    /// proves that a cluster being deleted returns before the reconciler touches the Kubernetes
+    /// API, and because the spec is invalid, before the [`DeserializeGuard`] is unwrapped.
+    #[test]
+    fn reconcile_exits_early_for_deleted_cluster() {
+        let object = serde_yaml::from_str(
+            r#"
+apiVersion: spark.stackable.tech/v1alpha1
+kind: SparkHistoryServer
+metadata:
+  name: spark-history
+  namespace: default
+  deletionTimestamp: "2026-08-14T12:00:00Z"
+spec: {}
+"#,
+        )
+        .expect("YAML parses; the invalid spec is captured inside the DeserializeGuard");
+
+        let action = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread tokio runtime")
+            .block_on(async {
+                let ctx = Arc::new(Ctx {
+                    client: Client::new(
+                        KubeClient::try_from(Config::new(
+                            "http://127.0.0.1:1".parse().expect("valid static URI"),
+                        ))
+                        .expect("client from static config"),
+                        None,
+                        "default".to_owned(),
+                        KubernetesClusterInfo {
+                            cluster_domain: DomainName::from_str("cluster.local")
+                                .expect("valid cluster domain"),
+                        },
+                    ),
+                    operator_environment: OperatorEnvironmentOptions {
+                        operator_namespace: "stackable-operators".to_owned(),
+                        operator_service_name: "spark-k8s-operator".to_owned(),
+                        image_repository: "oci.stackable.tech/sdp".to_owned(),
+                    },
+                });
+
+                reconcile(Arc::new(object), ctx).await
+            })
+            .expect("a deleted cluster reconciles without any API call");
+
+        assert_eq!(action, Action::await_change());
     }
 }

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -11,10 +11,13 @@ use history::controller;
 use stackable_operator::{
     YamlSchema,
     cli::{Command, OperatorEnvironmentOptions, RunArguments},
+    crd::listener,
     eos::EndOfSupportChecker,
     k8s_openapi::api::{
         apps::v1::StatefulSet,
-        core::v1::{ConfigMap, Pod, Service},
+        core::v1::{ConfigMap, Pod, Service, ServiceAccount},
+        policy::v1::PodDisruptionBudget,
+        rbac::v1::RoleBinding,
     },
     kube::{
         CustomResourceExt as _,
@@ -252,7 +255,19 @@ async fn main() -> anyhow::Result<()> {
                 watcher::Config::default(),
             )
             .owns(
-                watch_namespace.get_api::<DeserializeGuard<StatefulSet>>(&client),
+                watch_namespace.get_api::<DeserializeGuard<ConfigMap>>(&client),
+                watcher::Config::default(),
+            )
+            .owns(
+                watch_namespace.get_api::<DeserializeGuard<listener::v1alpha1::Listener>>(&client),
+                watcher::Config::default(),
+            )
+            .owns(
+                watch_namespace.get_api::<DeserializeGuard<PodDisruptionBudget>>(&client),
+                watcher::Config::default(),
+            )
+            .owns(
+                watch_namespace.get_api::<DeserializeGuard<RoleBinding>>(&client),
                 watcher::Config::default(),
             )
             .owns(
@@ -260,7 +275,11 @@ async fn main() -> anyhow::Result<()> {
                 watcher::Config::default(),
             )
             .owns(
-                watch_namespace.get_api::<DeserializeGuard<ConfigMap>>(&client),
+                watch_namespace.get_api::<DeserializeGuard<ServiceAccount>>(&client),
+                watcher::Config::default(),
+            )
+            .owns(
+                watch_namespace.get_api::<DeserializeGuard<StatefulSet>>(&client),
                 watcher::Config::default(),
             )
             .graceful_shutdown_on(sigterm_watcher.handle())
@@ -317,7 +336,15 @@ async fn main() -> anyhow::Result<()> {
                 watcher::Config::default(),
             )
             .owns(
-                watch_namespace.get_api::<DeserializeGuard<StatefulSet>>(&client),
+                watch_namespace.get_api::<DeserializeGuard<ConfigMap>>(&client),
+                watcher::Config::default(),
+            )
+            .owns(
+                watch_namespace.get_api::<DeserializeGuard<listener::v1alpha1::Listener>>(&client),
+                watcher::Config::default(),
+            )
+            .owns(
+                watch_namespace.get_api::<DeserializeGuard<RoleBinding>>(&client),
                 watcher::Config::default(),
             )
             .owns(
@@ -325,7 +352,11 @@ async fn main() -> anyhow::Result<()> {
                 watcher::Config::default(),
             )
             .owns(
-                watch_namespace.get_api::<DeserializeGuard<ConfigMap>>(&client),
+                watch_namespace.get_api::<DeserializeGuard<ServiceAccount>>(&client),
+                watcher::Config::default(),
+            )
+            .owns(
+                watch_namespace.get_api::<DeserializeGuard<StatefulSet>>(&client),
                 watcher::Config::default(),
             )
             .graceful_shutdown_on(sigterm_watcher.handle())

--- a/rust/operator-binary/src/spark_k8s_controller.rs
+++ b/rust/operator-binary/src/spark_k8s_controller.rs
@@ -8,7 +8,7 @@ use stackable_operator::{
         rbac::v1::RoleBinding,
     },
     kube::{
-        ResourceExt,
+        Resource, ResourceExt,
         core::{DeserializeGuard, error_boundary},
         runtime::controller::Action,
     },
@@ -89,6 +89,10 @@ pub async fn reconcile(
 ) -> Result<Action> {
     tracing::info!("Starting reconcile");
 
+    if spark_application.meta().deletion_timestamp.is_some() {
+        return Ok(Action::await_change());
+    }
+
     let spark_application = spark_application
         .0
         .as_ref()
@@ -141,5 +145,70 @@ pub fn error_policy(
     match error {
         Error::InvalidSparkApplication { .. } => Action::await_change(),
         _ => Action::requeue(*Duration::from_secs(5)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use stackable_operator::{
+        cli::OperatorEnvironmentOptions,
+        client::Client,
+        commons::networking::DomainName,
+        kube::{Client as KubeClient, Config},
+        utils::cluster_info::KubernetesClusterInfo,
+    };
+
+    use super::*;
+
+    /// The client points at a closed port, so any API call would fail the reconciliation: an `Ok`
+    /// proves that a cluster being deleted returns before the reconciler touches the Kubernetes
+    /// API, and because the spec is invalid, before the [`DeserializeGuard`] is unwrapped.
+    #[test]
+    fn reconcile_exits_early_for_deleted_cluster() {
+        let object = serde_yaml::from_str(
+            r#"
+apiVersion: spark.stackable.tech/v1alpha1
+kind: SparkApplication
+metadata:
+  name: spark-app
+  namespace: default
+  deletionTimestamp: "2026-08-14T12:00:00Z"
+spec: {}
+"#,
+        )
+        .expect("YAML parses; the invalid spec is captured inside the DeserializeGuard");
+
+        let action = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread tokio runtime")
+            .block_on(async {
+                let ctx = Arc::new(Ctx {
+                    client: Client::new(
+                        KubeClient::try_from(Config::new(
+                            "http://127.0.0.1:1".parse().expect("valid static URI"),
+                        ))
+                        .expect("client from static config"),
+                        None,
+                        "default".to_owned(),
+                        KubernetesClusterInfo {
+                            cluster_domain: DomainName::from_str("cluster.local")
+                                .expect("valid cluster domain"),
+                        },
+                    ),
+                    operator_environment: OperatorEnvironmentOptions {
+                        operator_namespace: "stackable-operators".to_owned(),
+                        operator_service_name: "spark-k8s-operator".to_owned(),
+                        image_repository: "oci.stackable.tech/sdp".to_owned(),
+                    },
+                });
+
+                reconcile(Arc::new(object), ctx).await
+            })
+            .expect("a deleted cluster reconciles without any API call");
+
+        assert_eq!(action, Action::await_change());
     }
 }

--- a/rust/operator-binary/src/spark_k8s_controller.rs
+++ b/rust/operator-binary/src/spark_k8s_controller.rs
@@ -150,65 +150,26 @@ pub fn error_policy(
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
-    use stackable_operator::{
-        cli::OperatorEnvironmentOptions,
-        client::Client,
-        commons::networking::DomainName,
-        kube::{Client as KubeClient, Config},
-        utils::cluster_info::KubernetesClusterInfo,
-    };
+    use indoc::indoc;
 
     use super::*;
+    use crate::test_support::assert_reconcile_exits_early;
 
-    /// The client points at a closed port, so any API call would fail the reconciliation: an `Ok`
-    /// proves that a cluster being deleted returns before the reconciler touches the Kubernetes
-    /// API, and because the spec is invalid, before the [`DeserializeGuard`] is unwrapped.
+    /// A `SparkApplication` marked for deletion must be reconciled without any API call. The
+    /// invalid spec additionally pins the early return above the [`DeserializeGuard`] unwrap.
     #[test]
     fn reconcile_exits_early_for_deleted_cluster() {
-        let object = serde_yaml::from_str(
-            r#"
-apiVersion: spark.stackable.tech/v1alpha1
-kind: SparkApplication
-metadata:
-  name: spark-app
-  namespace: default
-  deletionTimestamp: "2026-08-14T12:00:00Z"
-spec: {}
-"#,
-        )
-        .expect("YAML parses; the invalid spec is captured inside the DeserializeGuard");
-
-        let action = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("current-thread tokio runtime")
-            .block_on(async {
-                let ctx = Arc::new(Ctx {
-                    client: Client::new(
-                        KubeClient::try_from(Config::new(
-                            "http://127.0.0.1:1".parse().expect("valid static URI"),
-                        ))
-                        .expect("client from static config"),
-                        None,
-                        "default".to_owned(),
-                        KubernetesClusterInfo {
-                            cluster_domain: DomainName::from_str("cluster.local")
-                                .expect("valid cluster domain"),
-                        },
-                    ),
-                    operator_environment: OperatorEnvironmentOptions {
-                        operator_namespace: "stackable-operators".to_owned(),
-                        operator_service_name: "spark-k8s-operator".to_owned(),
-                        image_repository: "oci.stackable.tech/sdp".to_owned(),
-                    },
-                });
-
-                reconcile(Arc::new(object), ctx).await
-            })
-            .expect("a deleted cluster reconciles without any API call");
-
-        assert_eq!(action, Action::await_change());
+        assert_reconcile_exits_early(
+            indoc! {r#"
+                apiVersion: spark.stackable.tech/v1alpha1
+                kind: SparkApplication
+                metadata:
+                  name: spark-app
+                  namespace: default
+                  deletionTimestamp: "2026-08-14T12:00:00Z"
+                spec: {}
+            "#},
+            reconcile,
+        );
     }
 }

--- a/rust/operator-binary/src/test_support.rs
+++ b/rust/operator-binary/src/test_support.rs
@@ -1,5 +1,18 @@
 //! Shared helpers for the crate's tests.
 
+use std::{fmt::Debug, future::Future, str::FromStr, sync::Arc};
+
+use serde::de::DeserializeOwned;
+use stackable_operator::{
+    cli::OperatorEnvironmentOptions,
+    client::Client,
+    commons::networking::DomainName,
+    kube::{Client as KubeClient, Config, core::DeserializeGuard, runtime::controller::Action},
+    utils::cluster_info::KubernetesClusterInfo,
+};
+
+use crate::Ctx;
+
 /// The expected `app.kubernetes.io/version` label value for the given product version.
 ///
 /// The `-stackable` suffix carries the operator's own version, which is `0.0.0-dev` on main
@@ -10,4 +23,53 @@ pub fn app_version_label(product_version: &str) -> String {
         "{product_version}-stackable{}",
         crate::built_info::PKG_VERSION
     )
+}
+
+/// Asserts that `reconcile` returns [`Action::await_change`] for the object described by `yaml`
+/// without ever reaching the Kubernetes API.
+///
+/// The client points at a closed port, so any API call would fail the reconciliation: an `Ok`
+/// proves that the reconciler returned before touching the Kubernetes API, and - for a `yaml`
+/// whose spec is invalid - before the [`DeserializeGuard`] was unwrapped. Callers pass a `yaml`
+/// carrying a `deletionTimestamp` and an invalid `spec` to cover both.
+pub fn assert_reconcile_exits_early<K, F, Fut, E>(yaml: &str, reconcile: F)
+where
+    DeserializeGuard<K>: DeserializeOwned,
+    F: FnOnce(Arc<DeserializeGuard<K>>, Arc<Ctx>) -> Fut,
+    Fut: Future<Output = Result<Action, E>>,
+    E: Debug,
+{
+    let object: DeserializeGuard<K> = serde_yaml::from_str(yaml)
+        .expect("YAML parses; the invalid spec is captured inside the DeserializeGuard");
+
+    let action = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("current-thread tokio runtime")
+        .block_on(async {
+            let ctx = Arc::new(Ctx {
+                client: Client::new(
+                    KubeClient::try_from(Config::new(
+                        "http://127.0.0.1:1".parse().expect("valid static URI"),
+                    ))
+                    .expect("client from static config"),
+                    None,
+                    "default".to_owned(),
+                    KubernetesClusterInfo {
+                        cluster_domain: DomainName::from_str("cluster.local")
+                            .expect("valid cluster domain"),
+                    },
+                ),
+                operator_environment: OperatorEnvironmentOptions {
+                    operator_namespace: "stackable-operators".to_owned(),
+                    operator_service_name: "spark-k8s-operator".to_owned(),
+                    image_repository: "oci.stackable.tech/sdp".to_owned(),
+                },
+            });
+
+            reconcile(Arc::new(object), ctx).await
+        })
+        .expect("an object marked for deletion reconciles without any API call");
+
+    assert_eq!(action, Action::await_change());
 }

--- a/tests/templates/kuttl/spark-connect/60-assert.yaml
+++ b/tests/templates/kuttl/spark-connect/60-assert.yaml
@@ -1,0 +1,71 @@
+---
+# The recreated StatefulSet must come back to ready, and the recreated objects must
+# carry an owner reference back to the SparkConnectServer so that garbage collection
+# still works for them.
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+metadata:
+  name: recreate-owned-resources
+timeout: 600
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: spark-connect-server
+  ownerReferences:
+    - apiVersion: spark.stackable.tech/v1alpha1
+      controller: true
+      kind: SparkConnectServer
+      name: spark-connect
+status:
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spark-connect-serviceaccount
+  ownerReferences:
+    - apiVersion: spark.stackable.tech/v1alpha1
+      controller: true
+      kind: SparkConnectServer
+      name: spark-connect
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: spark-connect-rolebinding
+  ownerReferences:
+    - apiVersion: spark.stackable.tech/v1alpha1
+      controller: true
+      kind: SparkConnectServer
+      name: spark-connect
+---
+apiVersion: listeners.stackable.tech/v1alpha1
+kind: Listener
+metadata:
+  name: spark-connect-server
+  ownerReferences:
+    - apiVersion: spark.stackable.tech/v1alpha1
+      controller: true
+      kind: SparkConnectServer
+      name: spark-connect
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: spark-connect-server-headless
+  ownerReferences:
+    - apiVersion: spark.stackable.tech/v1alpha1
+      controller: true
+      kind: SparkConnectServer
+      name: spark-connect
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: spark-connect-server-metrics
+  ownerReferences:
+    - apiVersion: spark.stackable.tech/v1alpha1
+      controller: true
+      kind: SparkConnectServer
+      name: spark-connect

--- a/tests/templates/kuttl/spark-connect/60-delete-owned-resources.yaml
+++ b/tests/templates/kuttl/spark-connect/60-delete-owned-resources.yaml
@@ -1,0 +1,60 @@
+---
+# Every resource the connect controller applies carries an ownerReference and a `.owns()`
+# watch (main.rs): deleting it must trigger a reconcile of the SparkConnectServer that
+# re-applies it, proving the `.owns()` routing and the ClusterRole `watch` verbs end
+# to end.
+#
+# Resources are discovered by label (ClusterResources::add enforces the labels on
+# everything the controller applies), so new resources and kinds are covered
+# automatically. Labels over-match on derived objects, so each match must also carry
+# a controller ownerReference pointing at the SparkConnectServer; kinds that can never pass
+# that gate are excluded up front. Recreation is proven by UID change, and a floor
+# guard catches a selector that silently matches nothing.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: delete-owned-resources
+timeout: 300
+commands:
+  - script: |
+      set -eu
+
+      delete_and_await_recreation() {
+        resource=$1
+        old_uid=$(kubectl get -n "$NAMESPACE" "$resource" -o jsonpath='{.metadata.uid}')
+        kubectl delete -n "$NAMESPACE" "$resource" --wait=false
+        # Recreation is a single reconcile away, so this normally succeeds on the
+        # first iteration; 30s is a generous upper bound well below the step timeout.
+        for _ in $(seq 1 30); do
+          new_uid=$(kubectl get -n "$NAMESPACE" "$resource" -o jsonpath='{.metadata.uid}' 2>/dev/null || true)
+          if [ -n "$new_uid" ] && [ "$new_uid" != "$old_uid" ]; then
+            return 0
+          fi
+          sleep 1
+        done
+        echo "$resource was not recreated (old uid: $old_uid, current: '${new_uid:-}')" >&2
+        return 1
+      }
+
+      selector="app.kubernetes.io/instance=spark-connect,app.kubernetes.io/managed-by=spark.stackable.tech_connect"
+      excluded="^(pods|persistentvolumeclaims|endpoints|events|secrets)$|^endpointslices\.|^controllerrevisions\.|^events\."
+
+      deleted=0
+      for kind in $(kubectl api-resources --verbs=list --namespaced -o name | grep -Ev "$excluded" | sort); do
+        for resource in $(kubectl get -n "$NAMESPACE" "$kind" -l "$selector" -o name 2>/dev/null); do
+          owner=$(kubectl get -n "$NAMESPACE" "$resource" -o jsonpath='{.metadata.ownerReferences[?(@.controller==true)].kind}/{.metadata.ownerReferences[?(@.controller==true)].name}' 2>/dev/null || true)
+          if [ "$owner" != "SparkConnectServer/spark-connect" ]; then
+            echo "skipping $resource: controller owner is '${owner:-none}', not the SparkConnectServer"
+            continue
+          fi
+          delete_and_await_recreation "$resource"
+          deleted=$((deleted + 1))
+        done
+      done
+
+      # Guard against the sweep silently matching nothing (wrong selector, renamed
+      # labels): the fixture is known to produce well over this many owned resources.
+      if [ "$deleted" -lt 6 ]; then
+        echo "only $deleted labelled resources were swept - the label selector is broken" >&2
+        exit 1
+      fi

--- a/tests/templates/kuttl/spark-history-server/40-assert.yaml
+++ b/tests/templates/kuttl/spark-history-server/40-assert.yaml
@@ -1,0 +1,51 @@
+---
+# The recreated StatefulSet must come back to ready, and the recreated objects must
+# carry an owner reference back to the SparkHistoryServer so that garbage collection
+# still works for them.
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+metadata:
+  name: recreate-owned-resources
+timeout: 600
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: spark-history-node-default
+  ownerReferences:
+    - apiVersion: spark.stackable.tech/v1alpha1
+      controller: true
+      kind: SparkHistoryServer
+      name: spark-history
+status:
+  readyReplicas: 1
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: spark-history-node
+  ownerReferences:
+    - apiVersion: spark.stackable.tech/v1alpha1
+      controller: true
+      kind: SparkHistoryServer
+      name: spark-history
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spark-history-serviceaccount
+  ownerReferences:
+    - apiVersion: spark.stackable.tech/v1alpha1
+      controller: true
+      kind: SparkHistoryServer
+      name: spark-history
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: spark-history-rolebinding
+  ownerReferences:
+    - apiVersion: spark.stackable.tech/v1alpha1
+      controller: true
+      kind: SparkHistoryServer
+      name: spark-history

--- a/tests/templates/kuttl/spark-history-server/40-delete-owned-resources.yaml
+++ b/tests/templates/kuttl/spark-history-server/40-delete-owned-resources.yaml
@@ -1,0 +1,60 @@
+---
+# Every resource the history controller applies carries an ownerReference and a `.owns()`
+# watch (main.rs): deleting it must trigger a reconcile of the SparkHistoryServer that
+# re-applies it, proving the `.owns()` routing and the ClusterRole `watch` verbs end
+# to end.
+#
+# Resources are discovered by label (ClusterResources::add enforces the labels on
+# everything the controller applies), so new resources and kinds are covered
+# automatically. Labels over-match on derived objects, so each match must also carry
+# a controller ownerReference pointing at the SparkHistoryServer; kinds that can never pass
+# that gate are excluded up front. Recreation is proven by UID change, and a floor
+# guard catches a selector that silently matches nothing.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: delete-owned-resources
+timeout: 300
+commands:
+  - script: |
+      set -eu
+
+      delete_and_await_recreation() {
+        resource=$1
+        old_uid=$(kubectl get -n "$NAMESPACE" "$resource" -o jsonpath='{.metadata.uid}')
+        kubectl delete -n "$NAMESPACE" "$resource" --wait=false
+        # Recreation is a single reconcile away, so this normally succeeds on the
+        # first iteration; 30s is a generous upper bound well below the step timeout.
+        for _ in $(seq 1 30); do
+          new_uid=$(kubectl get -n "$NAMESPACE" "$resource" -o jsonpath='{.metadata.uid}' 2>/dev/null || true)
+          if [ -n "$new_uid" ] && [ "$new_uid" != "$old_uid" ]; then
+            return 0
+          fi
+          sleep 1
+        done
+        echo "$resource was not recreated (old uid: $old_uid, current: '${new_uid:-}')" >&2
+        return 1
+      }
+
+      selector="app.kubernetes.io/instance=spark-history,app.kubernetes.io/managed-by=spark.stackable.tech_history"
+      excluded="^(pods|persistentvolumeclaims|endpoints|events|secrets)$|^endpointslices\.|^controllerrevisions\.|^events\."
+
+      deleted=0
+      for kind in $(kubectl api-resources --verbs=list --namespaced -o name | grep -Ev "$excluded" | sort); do
+        for resource in $(kubectl get -n "$NAMESPACE" "$kind" -l "$selector" -o name 2>/dev/null); do
+          owner=$(kubectl get -n "$NAMESPACE" "$resource" -o jsonpath='{.metadata.ownerReferences[?(@.controller==true)].kind}/{.metadata.ownerReferences[?(@.controller==true)].name}' 2>/dev/null || true)
+          if [ "$owner" != "SparkHistoryServer/spark-history" ]; then
+            echo "skipping $resource: controller owner is '${owner:-none}', not the SparkHistoryServer"
+            continue
+          fi
+          delete_and_await_recreation "$resource"
+          deleted=$((deleted + 1))
+        done
+      done
+
+      # Guard against the sweep silently matching nothing (wrong selector, renamed
+      # labels): the fixture is known to produce well over this many owned resources.
+      if [ "$deleted" -lt 5 ]; then
+        echo "only $deleted labelled resources were swept - the label selector is broken" >&2
+        exit 1
+      fi


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/issues/issues/878

This PR ensures that the operator now watches all resources that it creates and early-exits the reconcile action when the cluster is marked for deletion. This is tested at unit-test level, as well as by adding a step to one of the kuttl tests to delete all relevant objects and assert that they are re-created.

```
--- PASS: kuttl (620.42s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/spark-history-server_openshift-false_spark-4.1.2_s3-use-tls-true (620.41s)
PASS
```
```
--- PASS: kuttl (868.02s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/spark-connect-kerberos_openshift-false_iceberg-latest-1.11.0_hive-iceberg-4.0.0_spark-connect-4.1.2_krb5-1.21.1_kerberos-realm-CLUSTER.LOCAL_s3-use-tls-true (787.25s)
        --- PASS: kuttl/harness/spark-connect_openshift-false_iceberg-latest-1.11.0_hive-iceberg-4.0.0_spark-connect-4.1.2_s3-use-tls-true (868.01s)
PASS
```


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [x] Release note snippet added in parent issue

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
