### PR TITLE
Add docs on appending to extraClassPath

### DIFF
--- a/docs/modules/spark-k8s/pages/usage-guide/overrides.adoc
+++ b/docs/modules/spark-k8s/pages/usage-guide/overrides.adoc
@@ -146,7 +146,6 @@ spec:
   ...
 ----
 
-
 == Pod overrides
 
 The Spark operator also supports Pod overrides, allowing you to override any property that you can set on a Kubernetes Pod.
@@ -156,6 +155,25 @@ Read the xref:concepts:overrides.adoc#pod-overrides[Pod overrides documentation]
 
 Stackable operators automatically determine the set of needed JVM arguments, such as memory settings or trust- and keystores.
 Using JVM argument overrides you can configure the JVM arguments xref:concepts:overrides.adoc#jvm-argument-overrides[according to the concepts page].
+
+=== Overriding `extraClassPath`
+
+The current implementation of `extraClassPath` overrides is a replace. Thus if you want to override `extraClassPath` you will need to append to the already set defaults you might need e.g. for `spark-connect`:
+
+[source,yaml]
+----
+---
+spec:
+  sparkImage:
+    productVersion: 4.1.2
+  mode: cluster
+  sparkConf:
+    "spark.driver.extraClassPath": "/stackable/spark/extra-jars/*:/stackable/spark/connect/spark-connect-4.1.2.jar:/mydependencies/my.jar" #<1>
+    "spark.executor.extraClassPath": "/stackable/spark/extra-jars/*:/stackable/spark/connect/spark-connect-4.1.2.jar:/mydependencies/my.jar"
+----
+<1> First two entries are defaults set by the operator when using `spark-connect`, the last one is user specific.
+
+Omitting the defaults set by the operator leads to a override and thus to incomplete `extraClassPath`.
 
 === Spark application
 

--- a/docs/modules/spark-k8s/pages/usage-guide/overrides.adoc
+++ b/docs/modules/spark-k8s/pages/usage-guide/overrides.adoc
@@ -166,7 +166,6 @@ The current implementation of `extraClassPath` overrides is a replace. Thus if y
 spec:
   sparkImage:
     productVersion: 4.1.2
-  mode: cluster
   sparkConf:
     "spark.driver.extraClassPath": "/stackable/spark/extra-jars/*:/stackable/spark/connect/spark-connect-4.1.2.jar:/mydependencies/my.jar" #<1>
     "spark.executor.extraClassPath": "/stackable/spark/extra-jars/*:/stackable/spark/connect/spark-connect-4.1.2.jar:/mydependencies/my.jar"


### PR DESCRIPTION
## Description

Solves issue-comment https://github.com/stackabletech/spark-k8s-operator/pull/755#discussion_r3988069337

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
